### PR TITLE
Remove docker-build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,17 +16,6 @@ steps:
     - pull_request
     - tag
 
-- name: docker-build
-  image: plugins/docker
-  settings:
-    dockerfile: Dockerfile
-    repo: "rancher/gke-operator"
-    tag: "dev"
-    dry_run: true
-  when:
-    event:
-    - pull_request
-
 - name: docker-publish
   image: plugins/docker
   settings:


### PR DESCRIPTION
The docker-publish step already builds the image, so it doesn't need a
build step beforehand. The docker-build step doesn't make sense to run
on pull_request events since the Dockerfile pulls from the master branch
of the remote github repository and not the locally checked-out
repository, so just remove it so that it doesn't block pull requests.