### PR TITLE
Add controller.GetTokenSource function

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -14,6 +14,8 @@ import (
 	v12 "github.com/rancher/gke-operator/pkg/generated/controllers/gke.cattle.io/v1"
 	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+
 	gkeapi "google.golang.org/api/container/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -716,4 +718,17 @@ func (h *Handler) createCASecret(config *gkev1.GKEClusterConfig, cluster *gkeapi
 			},
 		})
 	return err
+}
+
+func GetTokenSource(ctx context.Context, secretsCache wranglerv1.SecretCache, configSpec *gkev1.GKEClusterConfigSpec) (oauth2.TokenSource, error) {
+
+	cred, err := getSecret(ctx, secretsCache, configSpec)
+	if err != nil {
+		return nil, fmt.Errorf("error getting secret: %w", err)
+	}
+	ts, err := gke.GetTokenSource(ctx, cred)
+	if err != nil {
+		return nil, fmt.Errorf("error getting oauth2 token: %w", err)
+	}
+	return ts, nil
 }

--- a/internal/gke/client.go
+++ b/internal/gke/client.go
@@ -11,7 +11,7 @@ import (
 
 // GetGKEClient accepts a JSON credential string and returns a Service client.
 func GetGKEClient(ctx context.Context, credential string) (*gkeapi.Service, error) {
-	ts, err := getTokenSource(ctx, credential)
+	ts, err := GetTokenSource(ctx, credential)
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +22,7 @@ func getServiceClientWithTokenSource(ctx context.Context, ts oauth2.TokenSource)
 	return gkeapi.NewService(ctx, option.WithHTTPClient(oauth2.NewClient(ctx, ts)))
 }
 
-func getTokenSource(ctx context.Context, credential string) (oauth2.TokenSource, error) {
+func GetTokenSource(ctx context.Context, credential string) (oauth2.TokenSource, error) {
 	ts, err := google.CredentialsFromJSON(ctx, []byte(credential), gkeapi.CloudPlatformScope)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The GKE handler in Rancher needs to be able to build an initial admin
kubeconfig in order to generate the first service account in the
cluster. Since gke-operator already knows how to get the credential
Secret and convert it to an OAuth2 token, it is convenient to expose
this as a public function that Rancher can use to authenticate to the
cluster.