### PR TITLE
Fix handling of region vs zone

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -188,7 +188,7 @@ func (h *Handler) OnGkeConfigRemoved(key string, config *gkev1.GKEClusterConfig)
 		return config, err
 	}
 
-	logrus.Infof("removing cluster %v from project %v, region/zone %v", config.Spec.ClusterName, config.Spec.ProjectID, config.Spec.Region)
+	logrus.Infof("removing cluster %v from project %v, region/zone %v", config.Spec.ClusterName, config.Spec.ProjectID, gke.Location(config.Spec.Region, config.Spec.Zone))
 	if err := gke.RemoveCluster(ctx, client, config); err != nil {
 		logrus.Debugf("error deleting cluster %s: %v", config.Spec.ClusterName, err)
 		return config, err
@@ -541,7 +541,7 @@ func GetCluster(ctx context.Context, secretsCache wranglerv1.SecretCache, config
 	cluster, err := client.Projects.
 		Locations.
 		Clusters.
-		Get(gke.ClusterRRN(configSpec.ProjectID, configSpec.Region, configSpec.ClusterName)).
+		Get(gke.ClusterRRN(configSpec.ProjectID, gke.Location(configSpec.Region, configSpec.Zone), configSpec.ClusterName)).
 		Context(ctx).
 		Do()
 	if err != nil {

--- a/examples/cluster-basic.yaml
+++ b/examples/cluster-basic.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: "example-cluster"
   description: "example cluster"
-  region: "us-west1-a"
+  region: "us-west1"
   projectID: "example-project"
   kubernetesVersion: "1.18.15-gke.1100"
   loggingService: ""

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: "example-cluster-b"
   description: "complex example cluster"
-  region: "us-west1-a"
+  zone: "us-west1-a"
   projectID: "example-project"
   kubernetesVersion: "1.18.15-gke.1100"
   loggingService: "none"

--- a/examples/cluster-registered.yaml
+++ b/examples/cluster-registered.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-registered-cluster
 spec:
   clusterName: "example-registered-cluster"
-  region: "us-west1-a"
+  region: "us-west1"
   projectID: "example-project"
   imported: true
   googleCredentialSecret: "cattle-global-data:cc-abcde"

--- a/examples/cluster.json
+++ b/examples/cluster.json
@@ -50,6 +50,6 @@
     "enablePrivateNodes": false
   },
   "projectID": "example-project",
-  "region": "us-west1-a",
+  "region": "us-west1",
   "zone": ""
 }

--- a/internal/gke/create.go
+++ b/internal/gke/create.go
@@ -28,7 +28,7 @@ func Create(ctx context.Context, client *gkeapi.Service, config *gkev1.GKECluste
 		Locations.
 		Clusters.
 		Create(
-			LocationRRN(config.Spec.ProjectID, config.Spec.Region),
+			LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
 			createClusterRequest).
 		Context(ctx).
 		Do()
@@ -44,7 +44,7 @@ func CreateNodePool(ctx context.Context, client *gkeapi.Service, config *gkev1.G
 	}
 
 	createNodePoolRequest, err := newNodePoolCreateRequest(
-		ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		nodePoolConfig,
 	)
 	if err != nil {
@@ -56,7 +56,7 @@ func CreateNodePool(ctx context.Context, client *gkeapi.Service, config *gkev1.G
 		Clusters.
 		NodePools.
 		Create(
-			ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			createNodePoolRequest,
 		).Context(ctx).Do()
 	if err != nil && strings.Contains(err.Error(), errWait) {
@@ -175,7 +175,7 @@ func validateCreateRequest(ctx context.Context, client *gkeapi.Service, config *
 	operation, err := client.Projects.
 		Locations.
 		Clusters.
-		List(LocationRRN(config.Spec.ProjectID, config.Spec.Region)).
+		List(LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
 		Context(ctx).
 		Do()
 	if err != nil {

--- a/internal/gke/delete.go
+++ b/internal/gke/delete.go
@@ -26,7 +26,7 @@ func RemoveCluster(ctx context.Context, client *gkeapi.Service, config *gkev1.GK
 		_, err := client.Projects.
 			Locations.
 			Clusters.
-			Delete(ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName)).
+			Delete(ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName)).
 			Context(ctx).
 			Do()
 		if err != nil && strings.Contains(err.Error(), errWait) {
@@ -48,7 +48,7 @@ func RemoveNodePool(ctx context.Context, client *gkeapi.Service, config *gkev1.G
 		Locations.
 		Clusters.
 		NodePools.
-		Delete(NodePoolRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName, nodePoolName)).
+		Delete(NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, nodePoolName)).
 		Context(ctx).
 		Do()
 	if err != nil && strings.Contains(err.Error(), errWait) {

--- a/internal/gke/relative_resource_name.go
+++ b/internal/gke/relative_resource_name.go
@@ -4,6 +4,16 @@ import (
 	"fmt"
 )
 
+// Location returns the region or zone depending on which is not set to empty.
+// Cluster creation validation should ensure that only one of region or zone is set, not both.
+func Location(region, zone string) string {
+	ret := region
+	if zone != "" {
+		ret = zone
+	}
+	return ret
+}
+
 // LocationRRN returns a Relative Resource Name representing a location. This
 // RRN can either represent a Region or a Zone. It can be used as the parent
 // attribute during cluster creation to create a zonal or regional cluster, or

--- a/internal/gke/update.go
+++ b/internal/gke/update.go
@@ -44,7 +44,7 @@ func UpdateMasterKubernetesVersion(ctx context.Context, client *gkeapi.Service, 
 			Locations.
 			Clusters.
 			Update(
-				ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 				&gkeapi.UpdateClusterRequest{
 					Update: &gkeapi.ClusterUpdate{
 						DesiredMasterVersion: *config.Spec.KubernetesVersion,
@@ -111,7 +111,7 @@ func UpdateClusterAddons(ctx context.Context, client *gkeapi.Service, config *gk
 			Locations.
 			Clusters.
 			Update(
-				ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 				&gkeapi.UpdateClusterRequest{
 					Update: clusterUpdate,
 				},
@@ -180,7 +180,7 @@ func UpdateMasterAuthorizedNetworks(
 			Locations.
 			Clusters.
 			Update(
-				ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 				&gkeapi.UpdateClusterRequest{
 					Update: clusterUpdate,
 				},
@@ -229,7 +229,7 @@ func UpdateLoggingMonitoringService(
 			Locations.
 			Clusters.
 			Update(
-				ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 				&gkeapi.UpdateClusterRequest{
 					Update: clusterUpdate,
 				},
@@ -259,7 +259,7 @@ func UpdateNetworkPolicyEnabled(
 			Locations.
 			Clusters.
 			SetNetworkPolicy(
-				ClusterRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName),
+				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 				&gkeapi.SetNetworkPolicyRequest{
 					NetworkPolicy: &gkeapi.NetworkPolicy{
 						Enabled:  *config.Spec.NetworkPolicyEnabled,
@@ -309,7 +309,7 @@ func UpdateNodePoolKubernetesVersionOrImageType(
 			Clusters.
 			NodePools.
 			Update(
-				NodePoolRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName, *nodePool.Name),
+				NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 				updateRequest,
 			).Context(ctx).
 			Do()
@@ -347,7 +347,7 @@ func UpdateNodePoolSize(
 		Clusters.
 		NodePools.
 		SetSize(
-			NodePoolRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName, *nodePool.Name),
+			NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 			&gkeapi.SetNodePoolSizeRequest{
 				NodeCount: *nodePool.InitialNodeCount,
 			},
@@ -400,7 +400,7 @@ func UpdateNodePoolAutoscaling(
 			Clusters.
 			NodePools.
 			SetAutoscaling(
-				NodePoolRRN(config.Spec.ProjectID, config.Spec.Region, config.Spec.ClusterName, *nodePool.Name),
+				NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 				updateRequest,
 			).Context(ctx).
 			Do()


### PR DESCRIPTION
In GKE, a cluster is created either in a Region or a Zone. The CRD
supports setting either and the controller validates that one but not
both is set. But without this patch, the operator was only respecting
the Region setting and never regarding the Zone. The examples also
incorrectly referred to an example Zone identifier in the Region
setting. This patch ensures that Zone will be used to identify the
cluster if it is used and fixes the examples to make sense.