### PR TITLE
Expand ipAllocation example

### DIFF
--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -13,6 +13,8 @@ spec:
   enableKubernetesAlpha: false
   clusterIpv4Cidr: ""
   ipAllocationPolicy:
+    createSubnetwork: true
+    subnetworkName: "new-example-subnet-for-cluster-b"
     clusterIpv4CidrBlock: "10.100.0.0/16"
     nodeIpv4CidrBlock: "10.101.0.0/16"
     servicesIpv4CidrBlock: "10.102.0.0/16"
@@ -74,7 +76,7 @@ spec:
     horizontalPodAutoscaling: true
   networkPolicyEnabled: true
   network: example-network
-  subnetwork: example-subnet
+  subnetwork: ""
   privateClusterConfig:
     enablePrivateEndpoint: false
     enablePrivateNodes: true


### PR DESCRIPTION
Not every attribute was covered in the cluster-full.yaml example. Add
the createSubnetwork and subnetworkName fields to the example and set
the cluster-level subnetwork field to empty to make the example work.

Relates to but does not fix https://github.com/rancher/rancher/issues/31662