### PR TITLE
Fix recordError function

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -124,6 +124,10 @@ func (h *Handler) recordError(onChange func(key string, config *gkev1.GKECluster
 			// GKE config is likely deleting
 			return config, err
 		}
+		if err != nil {
+			message = err.Error()
+		}
+
 		if config.Status.FailureMessage == message {
 			return config, err
 		}


### PR DESCRIPTION
The function that was supposed to set the FailureMessage status
attribute was not doing that. This change ensures the error from the
onChange handler is actually used and the cluster status is updated.