### PR TITLE
Remove publicEndpoint and privateEndpoint

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -611,8 +611,6 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 		newSpec.PrivateClusterConfig.EnablePrivateEndpoint = cluster.PrivateClusterConfig.EnablePrivateNodes
 		newSpec.PrivateClusterConfig.EnablePrivateNodes = cluster.PrivateClusterConfig.EnablePrivateNodes
 		newSpec.PrivateClusterConfig.MasterIpv4CidrBlock = cluster.PrivateClusterConfig.MasterIpv4CidrBlock
-		newSpec.PrivateClusterConfig.PrivateEndpoint = cluster.PrivateClusterConfig.PrivateEndpoint
-		newSpec.PrivateClusterConfig.PublicEndpoint = cluster.PrivateClusterConfig.PublicEndpoint
 	} else {
 		newSpec.PrivateClusterConfig.EnablePrivateEndpoint = false
 		newSpec.PrivateClusterConfig.EnablePrivateNodes = false

--- a/crds/gkeclusterconfig.yaml
+++ b/crds/gkeclusterconfig.yaml
@@ -209,12 +209,6 @@ spec:
                 masterIpv4CidrBlock:
                   nullable: true
                   type: string
-                privateEndpoint:
-                  nullable: true
-                  type: string
-                publicEndpoint:
-                  nullable: true
-                  type: string
               type: object
             projectID:
               nullable: true

--- a/internal/gke/create.go
+++ b/internal/gke/create.go
@@ -154,8 +154,6 @@ func newClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClust
 			EnablePrivateEndpoint: config.Spec.PrivateClusterConfig.EnablePrivateEndpoint,
 			EnablePrivateNodes:    config.Spec.PrivateClusterConfig.EnablePrivateNodes,
 			MasterIpv4CidrBlock:   config.Spec.PrivateClusterConfig.MasterIpv4CidrBlock,
-			PrivateEndpoint:       config.Spec.PrivateClusterConfig.PrivateEndpoint,
-			PublicEndpoint:        config.Spec.PrivateClusterConfig.PublicEndpoint,
 		}
 	}
 

--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -73,8 +73,6 @@ type GKEPrivateClusterConfig struct {
 	EnablePrivateEndpoint bool   `json:"enablePrivateEndpoint,omitempty"`
 	EnablePrivateNodes    bool   `json:"enablePrivateNodes,omitempty"`
 	MasterIpv4CidrBlock   string `json:"masterIpv4CidrBlock,omitempty"`
-	PrivateEndpoint       string `json:"privateEndpoint,omitempty"`
-	PublicEndpoint        string `json:"publicEndpoint,omitempty"`
 }
 
 type GKEClusterConfigStatus struct {


### PR DESCRIPTION
PrivateClusterConfig.PublicEndpoint and
PrivateClusterConfig.PrivateEndpoint are read-only informational
parameters in the GKE SDK[1]. They should never have been exposed as
configurable options here. Configuration of the public and private
endpoints is done via the EnablePrivateEndpoint toggle.

[1] https://pkg.go.dev/google.golang.org/api/container/v1#PrivateClusterConfig