### PR TITLE
Fix CACert encoding

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -734,13 +733,7 @@ func (h *Handler) createCASecret(config *gkev1.GKEClusterConfig, cluster *gkeapi
 	endpoint := cluster.Endpoint
 	var ca []byte
 	if cluster.MasterAuth != nil {
-		// ClusterCaCertificate is base64-encoded, so it needs to be decoded
-		// before being passed to secrets.Create which will reencode it
-		encodedCA := cluster.MasterAuth.ClusterCaCertificate
-		ca, err = base64.StdEncoding.DecodeString(encodedCA)
-		if err != nil {
-			return err
-		}
+		ca = []byte(cluster.MasterAuth.ClusterCaCertificate)
 	}
 
 	_, err = h.secrets.Create(


### PR DESCRIPTION
Without this change, the CA secret gets created from the raw CA
certificate, which means the resulting Secret is base64-encoded one
time. This caused a problem in Rancher which, for EKS, was relying on
not having to manage the encoding at all[1], but was accidentally
changed when GKE support was added. This change simplifies the secret
generator to just use the CA cert from GKE as-is without decoding, and
Rancher will be fixed to also not reencode it.

[1] https://github.com/rancher/rancher/blob/9007198a6b122e9daa43e5adc391beed8292ad0e/pkg/controllers/management/eks/eks_cluster_handler.go#L497
[2] https://github.com/rancher/rancher/commit/a6f0b91b8ab00bb342080c3d715d6000c450f05c#diff-a774fa3e1a522b4a76b3f3b100a84fa19e2166a41ed9414ec37bf2c57e70ffa9R248

Needed by https://github.com/rancher/rancher/pull/31930