### PR TITLE
Fix examples

### DIFF
--- a/examples/cluster-basic.yaml
+++ b/examples/cluster-basic.yaml
@@ -18,16 +18,7 @@ spec:
   - name: example-node-pool
     autoscaling:
       enabled: false
-    config:
-      diskSizeGb: 50
-      diskType: "pd-standard"
-      imageType: "cos"
-      localSsdCount: 0
-      labels: {}
-      machineType: ""
-      preemptible: false
-      oauthScopes: []
-      taints: []
+    config: {}
     labels: []
     initialNodeCount: 1
     maxPodsConstraint: 110

--- a/examples/cluster.json
+++ b/examples/cluster.json
@@ -27,22 +27,13 @@
       "autoscaling": {
         "enabled": false
       },
-      "config": {
-        "diskSizeGb": 50,
-        "diskType": "pd-standard",
-        "imageType": "cos",
-        "labels": {},
-        "localSsdCount": 0,
-        "machineType": "",
-        "oauthScopes": [],
-        "preemptible": false,
-        "taints": []
-      },
+      "config": {},
       "initialNodeCount": 1,
       "labels": [],
       "maxPodsConstraint": 110,
       "name": "example-node-pool",
-      "version": "1.18.16-gke.302"
+      "version": "1.18.16-gke.302",
+      "management": {}
     }
   ],
   "privateClusterConfig": {
@@ -52,5 +43,6 @@
   "projectID": "example-project",
   "region": "us-west1",
   "zone": "",
-  "locations": []
+  "locations": [],
+  "maintenanceWindow": ""
 }


### PR DESCRIPTION
Add missing fields "maintenanceWindow" and "management" to JSON example.
Simplify basic examples by leaving nodePool.config empty since it is a
nilable field. The cluster-full.yaml example contains a fully populated
node pool config.