### PR TITLE
Ignore already exists error for CA Secret creation

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -17,6 +17,7 @@ import (
 
 	gkeapi "google.golang.org/api/container/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -747,6 +748,10 @@ func (h *Handler) createCASecret(config *gkev1.GKEClusterConfig, cluster *gkeapi
 				"ca":       ca,
 			},
 		})
+	if errors.IsAlreadyExists(err) {
+		logrus.Debugf("CA secret [%s] already exists, ignoring", config.Name)
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
When clusters are imported there might be a race condition where the
GKEClusterConfig Status doesn't successfully get saved on the first try
and the controller will retry on its own. Without this patch, if it does
this, it would reattempt to create the CA secret and end up failing
trying to do this. This change ensures that there is no reattempt to
create the same CA secret, which also helps ensure that if there is a
legitimate failure to update the cluster config's Status then that
failure message isn't clobbered by this unrelated error.

https://github.com/rancher/rancher/issues/31952