### PR TITLE
Add gkePersistentDiskCsiDriverConfig

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -633,6 +633,11 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 			npc = !cluster.AddonsConfig.NetworkPolicyConfig.Disabled
 		}
 		newSpec.ClusterAddons.NetworkPolicyConfig = npc
+		csi := false
+		if cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig != nil {
+			csi = cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled
+		}
+		newSpec.ClusterAddons.GcePersistentDiskCsiDriverConfig = csi
 	}
 
 	if cluster.IpAllocationPolicy != nil {

--- a/crds/gkeclusterconfig.yaml
+++ b/crds/gkeclusterconfig.yaml
@@ -22,6 +22,8 @@ spec:
             clusterAddons:
               nullable: true
               properties:
+                gkePersistentDiskCsiDriverConfig:
+                  type: boolean
                 horizontalPodAutoscaling:
                   type: boolean
                 httpLoadBalancing:

--- a/examples/cluster-basic.yaml
+++ b/examples/cluster-basic.yaml
@@ -30,6 +30,7 @@ spec:
     httpLoadBalancing: false
     networkPolicyConfig: false
     horizontalPodAutoscaling: false
+    gkePersistentDiskCsiDriverConfig: true
   networkPolicyEnabled: false
   network: default
   subnetwork: default

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -80,6 +80,7 @@ spec:
     httpLoadBalancing: true
     networkPolicyConfig: true
     horizontalPodAutoscaling: true
+    gkePersistentDiskCsiDriverConfig: true
   networkPolicyEnabled: true
   network: example-network
   subnetwork: ""

--- a/examples/cluster.json
+++ b/examples/cluster.json
@@ -2,7 +2,8 @@
   "clusterAddons": {
     "horizontalPodAutoscaling": true,
     "httpLoadBalancing": true,
-    "networkPolicyConfig": true
+    "networkPolicyConfig": true,
+    "gkePersistentDiskCsiDriverConfig": true
   },
   "clusterIpv4Cidr": "",
   "clusterName": "example-cluster",

--- a/internal/gke/create.go
+++ b/internal/gke/create.go
@@ -111,6 +111,7 @@ func newClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClust
 	request.Cluster.AddonsConfig.HttpLoadBalancing = &gkeapi.HttpLoadBalancing{Disabled: !addons.HTTPLoadBalancing}
 	request.Cluster.AddonsConfig.HorizontalPodAutoscaling = &gkeapi.HorizontalPodAutoscaling{Disabled: !addons.HorizontalPodAutoscaling}
 	request.Cluster.AddonsConfig.NetworkPolicyConfig = &gkeapi.NetworkPolicyConfig{Disabled: !addons.NetworkPolicyConfig}
+	request.Cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig = &gkeapi.GcePersistentDiskCsiDriverConfig{Enabled: addons.GcePersistentDiskCsiDriverConfig}
 
 	request.Cluster.NodePools = make([]*gkeapi.NodePool, 0, len(config.Spec.NodePools))
 

--- a/internal/gke/update.go
+++ b/internal/gke/update.go
@@ -107,6 +107,15 @@ func UpdateClusterAddons(ctx context.Context, client *gkeapi.Service, config *gk
 			needsUpdate = true
 		}
 	}
+	if upstreamSpec.ClusterAddons.GcePersistentDiskCsiDriverConfig != addons.GcePersistentDiskCsiDriverConfig {
+		if clusterUpdate.DesiredAddonsConfig == nil {
+			clusterUpdate.DesiredAddonsConfig = &gkeapi.AddonsConfig{}
+		}
+		clusterUpdate.DesiredAddonsConfig.GcePersistentDiskCsiDriverConfig = &gkeapi.GcePersistentDiskCsiDriverConfig{
+			Enabled: addons.GcePersistentDiskCsiDriverConfig,
+		}
+		needsUpdate = true
+	}
 
 	if needsUpdate {
 		logrus.Infof("updating addon configuration for cluster [%s]", config.Name)

--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -80,9 +80,10 @@ type GKEClusterConfigStatus struct {
 }
 
 type GKEClusterAddons struct {
-	HTTPLoadBalancing        bool `json:"httpLoadBalancing,omitempty"`
-	HorizontalPodAutoscaling bool `json:"horizontalPodAutoscaling,omitempty"`
-	NetworkPolicyConfig      bool `json:"networkPolicyConfig,omitempty"`
+	HTTPLoadBalancing                bool `json:"httpLoadBalancing,omitempty"`
+	HorizontalPodAutoscaling         bool `json:"horizontalPodAutoscaling,omitempty"`
+	NetworkPolicyConfig              bool `json:"networkPolicyConfig,omitempty"`
+	GcePersistentDiskCsiDriverConfig bool `json:"gkePersistentDiskCsiDriverConfig,omitempty"`
 }
 
 type GKENodePoolConfig struct {


### PR DESCRIPTION
Add support for toggling GCE Persistent Disk CSI Driver[1]. This
defaults to enabled in the GKE console, so the Rancher UI will need to
do the same.

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/gce-pd-csi-driver