### PR TITLE
Add log message for imported clusters

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -203,6 +203,7 @@ func (h *Handler) OnGkeConfigRemoved(key string, config *gkev1.GKEClusterConfig)
 
 func (h *Handler) create(config *gkev1.GKEClusterConfig) (*gkev1.GKEClusterConfig, error) {
 	if config.Spec.Imported {
+		logrus.Infof("importing cluster [%s]", config.Name)
 		config = config.DeepCopy()
 		config.Status.Phase = gkeConfigImportingPhase
 		return h.gkeCC.UpdateStatus(config)


### PR DESCRIPTION
The operator logs an info message when cluster creation is started, but
gives no indication when a cluster is being imported. Add a log for when
a cluster import is starting.