### PR TITLE
Fix clusterAddons examples

### DIFF
--- a/examples/cluster-basic.yaml
+++ b/examples/cluster-basic.yaml
@@ -27,9 +27,9 @@ spec:
       autoRepair: true
       autoUpgrade: true
   clusterAddons:
-    httpLoadBalancing: false
+    httpLoadBalancing: true
     networkPolicyConfig: false
-    horizontalPodAutoscaling: false
+    horizontalPodAutoscaling: true
   networkPolicyEnabled: false
   network: default
   subnetwork: default

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -77,9 +77,9 @@ spec:
       autoRepair: false
       autoUpgrade: false
   clusterAddons:
-    httpLoadBalancing: true
+    httpLoadBalancing: false
     networkPolicyConfig: true
-    horizontalPodAutoscaling: true
+    horizontalPodAutoscaling: false
   networkPolicyEnabled: true
   network: example-network
   subnetwork: ""

--- a/examples/cluster.json
+++ b/examples/cluster.json
@@ -2,7 +2,7 @@
   "clusterAddons": {
     "horizontalPodAutoscaling": true,
     "httpLoadBalancing": true,
-    "networkPolicyConfig": true
+    "networkPolicyConfig": false
   },
   "clusterIpv4Cidr": "",
   "clusterName": "example-cluster",
@@ -21,7 +21,7 @@
     "enabled": false
   },
   "monitoringService": "",
-  "networkPolicyEnabled": true,
+  "networkPolicyEnabled": false,
   "nodePools": [
     {
       "autoscaling": {


### PR DESCRIPTION
The minimal YAML and JSON examples should use example values that match
the upstream defaults, so change httpLoadBalancing and
horizontalPodAutoscaling to true for those samples. This will match the
default settings for a cluster created via the GKE console with no
parameters changed. This change updates the full example to set the
converse of these settings, and updates the JSON example to use the
minimalist settings for networkPolicyEnabled and networkPolicyConfig.