### PR TITLE
Remove version validation for updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 replace k8s.io/client-go => k8s.io/client-go v0.18.0
 
 require (
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b
 	github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac
 	github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=


### PR DESCRIPTION
The validateUpdate method was adopted from eks-provider and mimicked its
kubernetes version validation, which ensures the provided version is
valid Semver and that the control plane and node versions are within a
constrained range of each other. This was causing a problem with GKE
versions as it was not always parsing the Semver components correctly
and would result in a confusing and incorrect error message like:

  versions for cluster [1.18.16-gke.300] and nodegroup [1.18.15-gke.1501] not compatible: all nodegroup kubernetes versionsmust be equal to or one minor version lower than the cluster kubernetes version

Rather than fix the version parsing, this change just removes this
validation. GKE does not place such strict constraints on the delta
between the control plane and node pool versions, you can even create a
cluster that is up to seven minor versions apart. The UI queries GKE for
valid versions to input, so as long as it does so there is no danger of
requesting an invalid version. This is also just an awkward place to do
this validation, since it's only validating particular attributes and
not the full update request, so if validation is needed it should be
done elsewhere.

https://github.com/rancher/rancher/issues/32141