### PR TITLE
Improve error message for create conflict

### DIFF
--- a/internal/gke/create.go
+++ b/internal/gke/create.go
@@ -192,7 +192,7 @@ func validateCreateRequest(ctx context.Context, client *gkeapi.Service, config *
 
 	for _, cluster := range operation.Clusters {
 		if cluster.Name == config.Spec.ClusterName {
-			return fmt.Errorf("cannot create cluster [%s] because a cluster in GKE exists with the same name", config.Spec.ClusterName)
+			return fmt.Errorf("cannot create cluster [%s] because a cluster in GKE exists with the same name, please delete and recreate with a different name", config.Spec.ClusterName)
 		}
 	}
 


### PR DESCRIPTION
If a cluster is created by the operator in the same location with the
same name as a cluster that already exists in GKE but is not known to
Rancher, GKE will reject the request, but the cluster name cannot be
edited. This change improves the error message that will be surfaced in
the UI so that users know how to handle the problem.

https://github.com/rancher/rancher/issues/32292