### PR TITLE
Add norman annotations for *string fields

### DIFF
--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -39,22 +39,22 @@ type GKEClusterConfigSpec struct {
 	Description                    string                             `json:"description"`
 	EnableKubernetesAlpha          *bool                              `json:"enableKubernetesAlpha"`
 	ClusterAddons                  *GKEClusterAddons                  `json:"clusterAddons"`
-	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr"`
+	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr" norman:"type=*string,notnullable"`
 	ProjectID                      string                             `json:"projectID"`
 	GoogleCredentialSecret         string                             `json:"googleCredentialSecret"`
 	ClusterName                    string                             `json:"clusterName"`
-	KubernetesVersion              *string                            `json:"kubernetesVersion"`
-	LoggingService                 *string                            `json:"loggingService"`
-	MonitoringService              *string                            `json:"monitoringService"`
+	KubernetesVersion              *string                            `json:"kubernetesVersion" norman:"type=*string,notnullable"`
+	LoggingService                 *string                            `json:"loggingService" norman:"type=*string,notnullable"`
+	MonitoringService              *string                            `json:"monitoringService" norman:"type=*string,notnullable"`
 	NodePools                      []GKENodePoolConfig                `json:"nodePools"`
-	Network                        *string                            `json:"network,omitempty"`
-	Subnetwork                     *string                            `json:"subnetwork,omitempty"`
+	Network                        *string                            `json:"network,omitempty" norman:"type=*string,notnullable"`
+	Subnetwork                     *string                            `json:"subnetwork,omitempty" norman:"type=*string,notnullable"`
 	NetworkPolicyEnabled           *bool                              `json:"networkPolicyEnabled,omitempty"`
 	PrivateClusterConfig           *GKEPrivateClusterConfig           `json:"privateClusterConfig,omitempty"`
 	IPAllocationPolicy             *GKEIPAllocationPolicy             `json:"ipAllocationPolicy,omitempty"`
 	MasterAuthorizedNetworksConfig *GKEMasterAuthorizedNetworksConfig `json:"masterAuthorizedNetworks,omitempty"`
 	Locations                      []string                           `json:"locations"`
-	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty"`
+	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty" norman:"type=*string,notnullable"`
 }
 
 type GKEIPAllocationPolicy struct {
@@ -90,8 +90,8 @@ type GKENodePoolConfig struct {
 	Config            *GKENodeConfig          `json:"config,omitempty"`
 	InitialNodeCount  *int64                  `json:"initialNodeCount,omitempty"`
 	MaxPodsConstraint *int64                  `json:"maxPodsConstraint,omitempty"`
-	Name              *string                 `json:"name,omitempty"`
-	Version           *string                 `json:"version,omitempty"`
+	Name              *string                 `json:"name,omitempty" norman:"type=*string,notnullable"`
+	Version           *string                 `json:"version,omitempty" norman:"type=*string,notnullable"`
 	Management        *GKENodePoolManagement  `json:"management,omitempty"`
 }
 


### PR DESCRIPTION
Without this patch, norman doesn't properly interpret *string types as
*strings and instead converts them to strings in the generated client
code, which prevents clients from treating these fields as nilable. To
fix this, we add an explicit type declaration in the norman tag as well
as a 'notnullable' annotation. This is counterintuitively used on fields
we expressly want to be nullable because otherwise norman interprets
''*string' as nullable and adds another * creating '**string' which is
not what we want.

Fixing the type parsing in norman would cause too many knock-on effects
in the other generated types in Rancher.

https://github.com/rancher/rancher/issues/32440