### PR TITLE
Fix label updates

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -560,7 +560,11 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 			Enabled: false,
 		},
 		Locations: cluster.Locations,
-		Labels:    cluster.ResourceLabels,
+	}
+	if cluster.ResourceLabels == nil {
+		newSpec.Labels = make(map[string]string, 0)
+	} else {
+		newSpec.Labels = cluster.ResourceLabels
 	}
 
 	networkPolicyEnabled := false


### PR DESCRIPTION
* Retry on conflict during enqueueUpdate

It is very important for the status update to succeed here, otherwise
the update loop will be entered again unnecessarily. For the cluster
label update, this means that even if the labels were successfully
updated, the controller will try to update them again but fail due to
having an out of date label fingerprint.

* Add retries to UpdateLabels

Unlike other update actions, updating GKE cluster labels is so fast that
the cluster object does not enter a RECONCILING state, and so
when checkAndUpdate is reentered it proceeds to check all fields for
update again. However, it also lags a tiny amount and the label
fingerprint and labels on the upstreamSpec and even on the newly fetched
cluster object might be out of sync with the real cluster, and so an
attempt to update them again causes a fingerprint mismatch error. This
change adds a retry to compensate for the fact that UpdateLabels is
being called twice.

* Fix upstream state for labels

If labels are not set on the gkeapi cluster object, they will appear as
`nil`, but they should be converted to an empty map so that it is
comparable to the applied cluster state.

https://github.com/rancher/rancher/issues/32433