### PR TITLE
Fix MaxPodsConstraint for routes-based cluster

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -638,10 +638,9 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 		}
 
 		newNP := gkev1.GKENodePoolConfig{
-			Name:              &np.Name,
-			Version:           &np.Version,
-			InitialNodeCount:  &np.InitialNodeCount,
-			MaxPodsConstraint: &np.MaxPodsConstraint.MaxPodsPerNode,
+			Name:             &np.Name,
+			Version:          &np.Version,
+			InitialNodeCount: &np.InitialNodeCount,
 		}
 
 		if np.Config != nil {
@@ -680,6 +679,9 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 			}
 		}
 
+		if np.MaxPodsConstraint != nil {
+			newNP.MaxPodsConstraint = &np.MaxPodsConstraint.MaxPodsPerNode
+		}
 		newSpec.NodePools = append(newSpec.NodePools, newNP)
 	}
 


### PR DESCRIPTION
The max pods setting is only available for VPC-native (alias IP)
clusters, so requiring to be set to something when UseIPAliases is false
will cause a validation error from GKE. This change loosens the
requirement that MaxPodsConstraint be non-nil on create, and fixes the
upstreamSpec builder to tolerate it not being set on the upstream
cluster.

https://github.com/rancher/rancher/issues/32585