### PR TITLE
Add label to CRD

### DIFF
--- a/charts/gke-operator-crd/templates/crds.yaml
+++ b/charts/gke-operator-crd/templates/crds.yaml
@@ -75,6 +75,12 @@ spec:
             kubernetesVersion:
               nullable: true
               type: string
+            labels:
+              additionalProperties:
+                nullable: true
+                type: string
+              nullable: true
+              type: object
             locations:
               items:
                 nullable: true


### PR DESCRIPTION
The PR that added the chart to this repo accidentally removed the label
field from the CRD. This change adds the label field back.