### PR TITLE
Follow up on labels issues

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -371,7 +371,7 @@ func (h *Handler) updateUpstreamClusterState(config *gkev1.GKEClusterConfig, ups
 	if err != nil {
 		return config, err
 	}
-	if changed == gke.Changed {
+	if changed == gke.Changed || changed == gke.Retry {
 		return h.enqueueUpdate(config)
 	}
 

--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -12,7 +12,6 @@ import (
 	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
-	"k8s.io/client-go/util/retry"
 
 	gkeapi "google.golang.org/api/container/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -123,6 +122,12 @@ func (h *Handler) recordError(onChange func(key string, config *gkev1.GKECluster
 			// GKE config is likely deleting
 			return config, err
 		}
+		if err != nil && errors.IsConflict(err) {
+			// If a conflict error happened on an UpdateStatus call, it is probably because the handler was working from an out of sync cached object.
+			// UpdateStatus returns an empty struct when it fails, so trying to run UpdateStatus again to record the failureMessage will also fail.
+			// Just return the error instead of attempting to update the failure message.
+			return nil, err
+		}
 		if err != nil {
 			message = err.Error()
 		}
@@ -144,7 +149,7 @@ func (h *Handler) recordError(onChange func(key string, config *gkev1.GKECluster
 		var recordErr error
 		config, recordErr = h.gkeCC.UpdateStatus(config)
 		if recordErr != nil {
-			logrus.Errorf("Error recording gkecc [%s] failure message: %s", config.Name, recordErr.Error())
+			logrus.Errorf("Error recording gkecc [%s] failure message: %s, original error: %s", config.Name, recordErr, err)
 		}
 		return config, err
 	}
@@ -284,17 +289,9 @@ func (h *Handler) enqueueUpdate(config *gkev1.GKEClusterConfig) (*gkev1.GKEClust
 		h.gkeEnqueue(config.Namespace, config.Name)
 		return config, nil
 	}
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var err error
-		config, err = h.gkeCC.Get(config.Namespace, config.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		config.Status.Phase = gkeConfigUpdatingPhase
-		config, err = h.gkeCC.UpdateStatus(config)
-		return err
-	})
-	return config, err
+	config = config.DeepCopy()
+	config.Status.Phase = gkeConfigUpdatingPhase
+	return h.gkeCC.UpdateStatus(config)
 }
 
 func (h *Handler) updateUpstreamClusterState(config *gkev1.GKEClusterConfig, upstreamSpec *gkev1.GKEClusterConfigSpec) (*gkev1.GKEClusterConfig, error) {

--- a/internal/gke/update.go
+++ b/internal/gke/update.go
@@ -7,13 +7,11 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/rancher/gke-operator/internal/utils"
 	gkev1 "github.com/rancher/gke-operator/pkg/apis/gke.cattle.io/v1"
 	"github.com/sirupsen/logrus"
 	gkeapi "google.golang.org/api/container/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Network Providers
@@ -375,38 +373,27 @@ func UpdateLabels(
 	if config.Spec.Labels == nil || reflect.DeepEqual(config.Spec.Labels, upstreamSpec.Labels) || (upstreamSpec.Labels == nil && len(config.Spec.Labels) == 0) {
 		return NotChanged, nil
 	}
-	logrus.Infof("updating cluster labels for cluster [%s]", config.Name)
-	backoff := wait.Backoff{
-		Duration: 5 * time.Second,
-		Steps:    2,
-	}
-	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		cluster, err := GetCluster(ctx, client, &config.Spec)
-		if err != nil {
-			return false, err
-		}
-		_, err = client.Projects.
-			Locations.
-			Clusters.
-			SetResourceLabels(
-				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
-				&gkeapi.SetLabelsRequest{
-					LabelFingerprint: cluster.LabelFingerprint,
-					ResourceLabels:   config.Spec.Labels,
-				},
-			).Context(ctx).
-			Do()
-		if err != nil && strings.Contains(err.Error(), "Labels could not be set due to fingerprint mismatch") {
-			logrus.Debug("retrying label update")
-			return false, nil
-		}
-		if err != nil {
-			logrus.Debugf("error during label update: %v", err)
-			return false, err
-		}
-		return true, nil
-	})
+	cluster, err := GetCluster(ctx, client, &config.Spec)
 	if err != nil {
+		return NotChanged, err
+	}
+	logrus.Infof("updating cluster labels for cluster [%s]", config.Name)
+	_, err = client.Projects.
+		Locations.
+		Clusters.
+		SetResourceLabels(
+			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
+			&gkeapi.SetLabelsRequest{
+				LabelFingerprint: cluster.LabelFingerprint,
+				ResourceLabels:   config.Spec.Labels,
+			},
+		).Context(ctx).
+		Do()
+	if err != nil {
+		if strings.Contains(err.Error(), "Labels could not be set due to fingerprint mismatch") {
+			logrus.Debugf("got transient error: %v, retrying", err)
+			return Retry, nil
+		}
 		return NotChanged, err
 	}
 	return Changed, nil


### PR DESCRIPTION
#  Fix setting failure message on empty resource

53dbce90 was an attempt to address the occurrence of resource conflict
errors during an UpdateStatus call to set the resource phase to
"updating". It helped reduce the frequency of this happening but it did
not fully address the issue because it was not the only place where the
resource state is updated.

The resource conflict error always occurs after an error has occurred
during the reconcile loop. Multiple status updates happen in quick
succession during a single loop, and upon entering the next loop, the
shared informer cache is not fully synced and the controller worker
fetches an out of date version of the resource object.

Without this change, when this happens, the recordError handler function
tries to continue persisting the error state to the resource object with
UpdateStatus, but since UpdateStatus returns an empty struct, there's no
object it can actually update at this point, and another error is
logged.

If this happens, just return the error right away instead of trying to
update an empty object.

# Ignore label mismatch error

Reverts 3244dfa5a and instead catches the fingerprint mismatch error and
downgrades it to a debug log. The reasoning behind that commit still
applies - the upstream GKE cluster is slightly delayed in processing the
label updates - but the controller will naturally retry the update, so
we don't need to block on retrying ourselves. This way the equality
check will also be done again and so the cluster won't be updated twice.

---

https://github.com/rancher/rancher/issues/32550