### PR TITLE
Fix version sed for chart version

### DIFF
--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -13,7 +13,7 @@ mkdir -p build dist/artifacts
 cp -rf charts build/
 
 sed -i \
-    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/^version:.*/version: '${HELM_VERSION}'/' \
     -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
     build/charts/gke-operator/Chart.yaml
 
@@ -22,7 +22,7 @@ sed -i \
     build/charts/gke-operator/values.yaml
 
 sed -i \
-    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/^version:.*/version: '${HELM_VERSION}'/' \
     -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
     build/charts/gke-operator-crd/Chart.yaml
 


### PR DESCRIPTION
The chart version sed command was inadvertently overwriting the
rancher-version annotation. This change fixes that issue.

Issue:
https://github.com/rancher/rancher/issues/32293