### PR TITLE
Use norman:"pointer" for nullable fields

### DIFF
--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -37,25 +37,25 @@ type GKEClusterConfigSpec struct {
 	Zone                           string                             `json:"zone" norman:"noupdate"`
 	Imported                       bool                               `json:"imported" norman:"noupdate"`
 	Description                    string                             `json:"description"`
-	Labels                         map[string]string                  `json:"labels"`
+	Labels                         map[string]string                  `json:"labels" norman:"pointer"`
 	EnableKubernetesAlpha          *bool                              `json:"enableKubernetesAlpha"`
 	ClusterAddons                  *GKEClusterAddons                  `json:"clusterAddons"`
-	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr"`
+	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr" norman:"pointer"`
 	ProjectID                      string                             `json:"projectID"`
 	GoogleCredentialSecret         string                             `json:"googleCredentialSecret"`
 	ClusterName                    string                             `json:"clusterName"`
-	KubernetesVersion              *string                            `json:"kubernetesVersion"`
-	LoggingService                 *string                            `json:"loggingService"`
-	MonitoringService              *string                            `json:"monitoringService"`
+	KubernetesVersion              *string                            `json:"kubernetesVersion" norman:"pointer"`
+	LoggingService                 *string                            `json:"loggingService" norman:"pointer"`
+	MonitoringService              *string                            `json:"monitoringService" norman:"pointer"`
 	NodePools                      []GKENodePoolConfig                `json:"nodePools"`
-	Network                        *string                            `json:"network,omitempty"`
-	Subnetwork                     *string                            `json:"subnetwork,omitempty"`
+	Network                        *string                            `json:"network,omitempty" norman:"pointer"`
+	Subnetwork                     *string                            `json:"subnetwork,omitempty" norman:"pointer"`
 	NetworkPolicyEnabled           *bool                              `json:"networkPolicyEnabled,omitempty"`
 	PrivateClusterConfig           *GKEPrivateClusterConfig           `json:"privateClusterConfig,omitempty"`
 	IPAllocationPolicy             *GKEIPAllocationPolicy             `json:"ipAllocationPolicy,omitempty"`
 	MasterAuthorizedNetworksConfig *GKEMasterAuthorizedNetworksConfig `json:"masterAuthorizedNetworks,omitempty"`
-	Locations                      []string                           `json:"locations"`
-	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty"`
+	Locations                      []string                           `json:"locations" norman:"pointer"`
+	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty" norman:"pointer"`
 }
 
 type GKEIPAllocationPolicy struct {
@@ -91,8 +91,8 @@ type GKENodePoolConfig struct {
 	Config            *GKENodeConfig          `json:"config,omitempty"`
 	InitialNodeCount  *int64                  `json:"initialNodeCount,omitempty"`
 	MaxPodsConstraint *int64                  `json:"maxPodsConstraint,omitempty"`
-	Name              *string                 `json:"name,omitempty"`
-	Version           *string                 `json:"version,omitempty"`
+	Name              *string                 `json:"name,omitempty" norman:"pointer"`
+	Version           *string                 `json:"version,omitempty" norman:"pointer"`
 	Management        *GKENodePoolManagement  `json:"management,omitempty"`
 }
 


### PR DESCRIPTION
Opt into new "pointer" field attribute from norman that will convert any
type to a pointer in the generated client code. The generated client code
includes "omitempty" JSON tags, which means that for maps and slices,
unset and empty values are both sent to the server as unset, which
breaks the cluster create validation. With this change, there's now a
difference between a nil value and an empty allocated map or slice in the
client code. Strings can now also use this attribute instead of the
"nullablestrings" type (a85378a/2450a6e).

Depends on https://github.com/rancher/norman/pull/400

https://github.com/rancher/rancher/issues/32553
https://github.com/rancher/rancher/issues/32440