### PR TITLE
Add additional trusted CAs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 bin/
 dist/
+.dapper

--- a/charts/gke-operator/templates/deployment.yaml
+++ b/charts/gke-operator/templates/deployment.yaml
@@ -25,3 +25,15 @@ spec:
           value: {{ .Values.httpsProxy }}
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
+{{- if .Values.additionalTrustedCAs }}
+        volumeMounts:
+          - mountPath: /etc/ssl/certs/ca-additional.pem
+            name: tls-ca-additional-volume
+            subPath: ca-additional.pem
+            readOnly: true
+      volumes:
+        - name: tls-ca-additional-volume
+          secret:
+            defaultMode: 0400
+            secretName: tls-ca-additional
+  {{- end }}

--- a/charts/gke-operator/values.yaml
+++ b/charts/gke-operator/values.yaml
@@ -9,3 +9,4 @@ gkeOperator:
 httpProxy: ""
 httpsProxy: ""
 noProxy: ""
+additionalTrustedCAs: false


### PR DESCRIPTION
When Rancher is installed on a cluster behind a proxy, the operator
should trust the proxy's certificate. It is passed to the deployment via
 a secret the user should setup per the Rancher documentation.

Issue:
https://github.com/rancher/rancher/issues/31846