### PR TITLE
Only send PrivateClusterConfig for private clusters

### DIFF
--- a/internal/gke/create.go
+++ b/internal/gke/create.go
@@ -147,7 +147,7 @@ func newClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClust
 		}
 	}
 
-	if config.Spec.PrivateClusterConfig != nil {
+	if config.Spec.PrivateClusterConfig != nil && config.Spec.PrivateClusterConfig.EnablePrivateNodes {
 		request.Cluster.PrivateClusterConfig = &gkeapi.PrivateClusterConfig{
 			EnablePrivateEndpoint: config.Spec.PrivateClusterConfig.EnablePrivateEndpoint,
 			EnablePrivateNodes:    config.Spec.PrivateClusterConfig.EnablePrivateNodes,
@@ -231,6 +231,9 @@ func validateCreateRequest(ctx context.Context, client *gkeapi.Service, config *
 	}
 	if config.Spec.PrivateClusterConfig == nil {
 		return fmt.Errorf(cannotBeNilError, "privateClusterConfig", config.Name)
+	}
+	if config.Spec.PrivateClusterConfig.EnablePrivateEndpoint && !config.Spec.PrivateClusterConfig.EnablePrivateNodes {
+		return fmt.Errorf("private endpoint requires private nodes for cluster [%s]", config.Name)
 	}
 	if config.Spec.MasterAuthorizedNetworksConfig == nil {
 		return fmt.Errorf(cannotBeNilError, "masterAuthorizedNetworksConfig", config.Name)


### PR DESCRIPTION
GKE rolled out a change that denies setting PrivateClusterConfig on
Cluster objects if they are not using private nodes, so update the
controller to conform with this.

Since PrivateClusterConfig is ignored if EnablePrivateNodes is false,
add validation to ensure the PrivateClusterConfig settings are valid.

Backport of https://github.com/rancher/gke-operator/pull/56