### PR TITLE
Add support for network tags

### DIFF
--- a/charts/gke-operator-crd/templates/crds.yaml
+++ b/charts/gke-operator-crd/templates/crds.yaml
@@ -163,6 +163,12 @@ spec:
                         type: array
                       preemptible:
                         type: boolean
+                      tags:
+                        items:
+                          nullable: true
+                          type: string
+                        nullable: true
+                        type: array
                       taints:
                         items:
                           properties:

--- a/examples/cluster-basic.yaml
+++ b/examples/cluster-basic.yaml
@@ -8,7 +8,7 @@ spec:
   labels: {}
   region: "us-west1"
   projectID: "example-project"
-  kubernetesVersion: "1.18.16-gke.302"
+  kubernetesVersion: "1.19.10-gke.1600"
   loggingService: ""
   monitoringService: ""
   enableKubernetesAlpha: false
@@ -23,7 +23,7 @@ spec:
     labels: []
     initialNodeCount: 1
     maxPodsConstraint: 110
-    version: "1.18.16-gke.302"
+    version: "1.19.10-gke.1600"
     management:
       autoRepair: true
       autoUpgrade: true

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -41,6 +41,9 @@ spec:
       - "https://www.googleapis.com/auth/compute"
       - "https://www.googleapis.com/auth/devstorage.read_only"
       - "https://www.googleapis.com/auth/cloud-platform"
+      tags:
+      - "red"
+      - "blue"
       taints:
       - effect: NO_SCHEDULE
         key: group
@@ -69,6 +72,9 @@ spec:
       preemptible: false
       oauthScopes: []
       taints: []
+      tags:
+      - "green"
+      - "yellow"
     labels:
     - "one"
     - "two"

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -9,7 +9,7 @@ spec:
     foo: bar
   zone: "us-west1-a"
   projectID: "example-project"
-  kubernetesVersion: "1.18.16-gke.302"
+  kubernetesVersion: "1.19.10-gke.1600"
   loggingService: "none"
   monitoringService: "none"
   enableKubernetesAlpha: true
@@ -50,7 +50,7 @@ spec:
     - "bar"
     initialNodeCount: 3
     maxPodsConstraint: 55
-    version: "1.18.16-gke.302"
+    version: "1.19.10-gke.1600"
     management:
       autoRepair: false
       autoUpgrade: false
@@ -74,7 +74,7 @@ spec:
     - "two"
     initialNodeCount: 3
     maxPodsConstraint: 110
-    version: "1.18.16-gke.302"
+    version: "1.19.10-gke.1600"
     management:
       autoRepair: false
       autoUpgrade: false

--- a/examples/cluster.json
+++ b/examples/cluster.json
@@ -15,7 +15,7 @@
   "ipAllocationPolicy": {
     "useIpAliases": true
   },
-  "kubernetesVersion": "1.18.16-gke.302",
+  "kubernetesVersion": "1.19.10-gke.1600",
   "loggingService": "",
   "masterAuthorizedNetworks": {
     "enabled": false
@@ -32,7 +32,7 @@
       "labels": [],
       "maxPodsConstraint": 110,
       "name": "example-node-pool",
-      "version": "1.18.16-gke.302",
+      "version": "1.19.10-gke.1600",
       "management": {}
     }
   ],

--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -111,6 +111,7 @@ type GKENodeConfig struct {
 	MachineType   string               `json:"machineType,omitempty"`
 	OauthScopes   []string             `json:"oauthScopes,omitempty"`
 	Preemptible   bool                 `json:"preemptible,omitempty"`
+	Tags          []string             `json:"tags,omitempty"`
 	Taints        []GKENodeTaintConfig `json:"taints,omitempty"`
 }
 

--- a/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
@@ -291,6 +291,11 @@ func (in *GKENodeConfig) DeepCopyInto(out *GKENodeConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]GKENodeTaintConfig, len(*in))

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -323,6 +323,7 @@ func newGKENodePoolFromConfig(np *gkev1.GKENodePoolConfig, config *gkev1.GKEClus
 			MachineType:   np.Config.MachineType,
 			OauthScopes:   np.Config.OauthScopes,
 			Preemptible:   np.Config.Preemptible,
+			Tags:          np.Config.Tags,
 			Taints:        taints,
 		},
 		Version: *np.Version,


### PR DESCRIPTION
Tags represent firewall rules applied to each node. Node tags cannot be
modified after the cluster is created.

https://cloud.google.com/vpc/docs/add-remove-network-tags

Also updated the kubernetes version in the examples for testing.

https://github.com/rancher/rancher/issues/33406