### PR TITLE
Add Tags to upstream spec builder

### DIFF
--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -649,6 +649,7 @@ func BuildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKEClusterConfig
 				LocalSsdCount: np.Config.LocalSsdCount,
 				MachineType:   np.Config.MachineType,
 				Preemptible:   np.Config.Preemptible,
+				Tags:          np.Config.Tags,
 			}
 
 			newNP.Config.Taints = make([]gkev1.GKENodeTaintConfig, 0, len(np.Config.Taints))


### PR DESCRIPTION
Without this, the true value of the nodepool tags was appearing empty in
the upstream spec.

https://github.com/rancher/rancher/issues/33406