### PR TITLE
Fix system default registry setting

### DIFF
--- a/charts/gke-operator/templates/_helpers.tpl
+++ b/charts/gke-operator/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "system_default_registry" -}}
-{{- if .Values.global.systemDefaultRegistry -}}
-{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/charts/gke-operator/values.yaml
+++ b/charts/gke-operator/values.yaml
@@ -1,5 +1,6 @@
 global:
-  systemDefaultRegistry: ""
+  cattle:
+    systemDefaultRegistry: ""
 
 gkeOperator:
   image:


### PR DESCRIPTION
Rancher sets the default registry under
`global.cattle.systemDefaultRegistry`. Without this change, the chart
wasn't picking up the setting and would still try to pull images from
dockerhub. This change aligns the setting with the way Rancher expects
to use it and with the way other charts expose it.

https://github.com/rancher/rancher/issues/35485