### PR TITLE
Remove norman:pointer tags from GKE operator

### DIFF
--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -37,7 +37,7 @@ type GKEClusterConfigSpec struct {
 	Zone                           string                             `json:"zone" norman:"noupdate"`
 	Imported                       bool                               `json:"imported" norman:"noupdate"`
 	Description                    string                             `json:"description"`
-	Labels                         map[string]string                  `json:"labels" norman:"pointer"`
+	Labels                         map[string]string                  `json:"labels"`
 	EnableKubernetesAlpha          *bool                              `json:"enableKubernetesAlpha"`
 	ClusterAddons                  *GKEClusterAddons                  `json:"clusterAddons"`
 	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr" norman:"pointer"`
@@ -54,7 +54,7 @@ type GKEClusterConfigSpec struct {
 	PrivateClusterConfig           *GKEPrivateClusterConfig           `json:"privateClusterConfig,omitempty"`
 	IPAllocationPolicy             *GKEIPAllocationPolicy             `json:"ipAllocationPolicy,omitempty"`
 	MasterAuthorizedNetworksConfig *GKEMasterAuthorizedNetworksConfig `json:"masterAuthorizedNetworks,omitempty"`
-	Locations                      []string                           `json:"locations" norman:"pointer"`
+	Locations                      []string                           `json:"locations"`
 	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty" norman:"pointer"`
 }
 


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/36128.

A KEv2 cluster imported with the rancher2 terraform provider will currently delete all node groups on import if no node groups are specified in the terraform config.

This is happening because the `NodeGroups` cluster config field (and all slices and maps) in the KEv2 operators have the `norman:pointer` tag. The problem is that the `norman:pointer` tag is added to fields that are already pointers. When node groups is not specified in the terraform config, terraform sets the node group field in the management cluster yaml as an empty array instead of null. If node groups is an empty array, Rancher deletes all node groups from the imported cluster because that is the template given: no node groups. Removing the incorrect tag will make node groups null and Rancher will take no action against imported clusters.

This fix is being made in the EKS, AKS, and GKE operators so node groups will never get deleted when a user tries to import a cluster with terraform.

Note: the node deletion bug is not a bug in GKE because the `GKENodePoolConfig` field didn't have an extra norman:pointer https://github.com/annablender/gke-operator/blob/81935f828160a4e74479729353b70f3eac0faa02/pkg/apis/gke.cattle.io/v1/types.go#L50. There were a few places where it was incorrect so I updated those.