### PR TITLE
🐛 Remove unnecessary labelling from dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,8 +9,6 @@ updates:
     interval: "weekly"
   commit-message:
     prefix: ":seedling:"
-  labels:
-    - "ok-to-test"
 # Go
 - package-ecosystem: "gomod"
   directory: "/"
@@ -26,5 +24,3 @@ updates:
     - dependency-name: "github.com/rancher/wrangler"
   commit-message:
     prefix: ":seedling:"
-  labels:
-    - "ok-to-test"


### PR DESCRIPTION
Removes unnecessary prow related labelling [comment](https://github.com/rancher/gke-operator/pull/116#issuecomment-1540072329) on dependabot PRs which is configured in the dependabot configuration