### PR TITLE
chore: added nightly publish of image for testing

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -1,0 +1,31 @@
+name: Nightly
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  nightly:
+    env:
+        REPO: ttl.sh/gke-operator-nightly
+        TAG: 1d
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Build binary
+        run: make build
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2.5.0
+      - name: Build and push image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          tags: ${{ env.REPO}}-${{ env.NOW }}:${{ env.TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: package/Dockerfile


### PR DESCRIPTION
This adds a new GHA workflow that builds the operator image every night and publishes it to ttl.sh.