### PR TITLE
fix: bump base image for bci-base to 15.5

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper update -y && \
     zypper -n clean -a && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*


### PR DESCRIPTION
#### Issue rancher/highlander#13

### Description

The base image `bci-base` is updated from `15.4` to `15.5` to fix the vulnerabilities reported by rancherlabs/image-scanning#2285 on the latest release of the operator.