### PR TITLE
Improve dependabot to track other branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
     interval: "weekly"
   commit-message:
     prefix: ":seedling:"
-# Go
+# Go modules in main branch
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -24,3 +24,36 @@ updates:
     - dependency-name: "github.com/rancher/wrangler"
   commit-message:
     prefix: ":seedling:"
+  target-branch: "main"
+# Go modules in release-v2.8 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+  commit-message:
+    prefix: ":seedling:"
+  target-branch: "release-v2.8"
+# Go modules in release-v2.7 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+  commit-message:
+    prefix: ":seedling:"
+  target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it:**

We have to check outdated dependency also for `release-v2.8` and `release-v2.7` branches

