### PR TITLE
chore: publish charts nightly with reusable workflow

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -2,30 +2,11 @@ name: Nightly
 on:
   schedule:
     - cron: '0 1 * * *'
+  workflow_dispatch:
 jobs:
-  nightly:
-    env:
-        REPO: ttl.sh/gke-operator-nightly
-        TAG: 1d
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-      - name: Build binary
-        run: make build
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y%m%d')" >> $GITHUB_ENV
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3.0.0
-      - name: Build and push image
-        uses: docker/build-push-action@v5.1.0
-        with:
-          context: .
-          tags: ${{ env.REPO}}-${{ env.NOW }}:${{ env.TAG }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          file: package/Dockerfile
+  publish_nightly:
+    uses: rancher-sandbox/highlander-reusable-workflows/.github/workflows/operator-with-latest-rancher-build.yaml@main
+    with:
+      operator_name: gke-operator
+      rancher_ref: release/v2.8
+      operator_commit: ${{ github.sha }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This uses the reusable workflow to publish charts nightly to ttl.sh, as we do with other operators.

**Which issue(s) this PR fixes**
Issue #137 

**Special notes for your reviewer**:

The reusable workflow's last step `build-push-chart` is failing because of operator version conflicts between rancher:v2.8 and the operator main branch. Issue https://github.com/rancher-sandbox/highlander-reusable-workflows/issues/2 keeps track of this.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
