### PR TITLE
Fix e2e daily tests

### DIFF
--- a/.github/workflows/e2e-latest-rancher.yaml
+++ b/.github/workflows/e2e-latest-rancher.yaml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/e2e.yaml
     secrets:
       GKE_CREDENTIALS: ${{ secrets.GKE_CREDENTIALS }}
+      GKE_PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,6 +5,13 @@ on:
       GKE_CREDENTIALS:
         description: "GKE credentials"
         required: true
+      GKE_PROJECT_ID:
+        description: "GKE project ID"
+        required: true
+env:
+  GKE_CREDENTIALS: ${{ secrets.GKE_CREDENTIALS }}
+  GKE_PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
+
 jobs:
   e2e-tests:
     env:
@@ -66,6 +73,10 @@ jobs:
           skipClusterCreation: "true"
       - name: Create kind cluster
         run: make setup-kind
+      - name: Set the value
+        run: |
+          GKE_PROJECT_ID="${{ env.GKE_PROJECT_ID }}"
+          echo "GKE_PROJECT_ID=${GKE_PROJECT_ID}" >> $GITHUB_ENV
       - name: E2E tests
         env:
           GKE_CREDENTIALS: "${{ secrets.GKE_CREDENTIALS }}"

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ We run e2e tests after every merged PR and periodically every 24 hours. They are
 
 For running e2e tests:
 
-1. Set at least a `projectID` to valid projectID in [GKEClusterConfig](./test/e2e/templates/basic-cluster.yaml) definition, which is used to provision a GKE cluster 
-2. Set `GKE_CREDENTIALS` environment variable by providing a full path to valid gke credentials JSON:
+1. Set `GKE_PROJECT_ID` and `GKE_CREDENTIALS` environment variables:
 
 ```sh
+    export GKE_PROJECT_ID="replace-with-your-value"
     export GKE_CREDENTIALS=$( cat /path/to/gke-credentials.json )
 ```
 
-3. and finally run:
+2. and finally run:
 
 ```sh
     make kind-e2e-tests

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -40,6 +40,7 @@ type E2EConfig struct {
 	RancherChartURL string `yaml:"rancherChartURL"`
 
 	GkeCredentials string `json:"gkeCredentials"`
+	GkeProjectID   string `yaml:"gkeProjectID"`
 }
 
 // ReadE2EConfig read config from yaml and substitute variables using envsubst.
@@ -98,6 +99,10 @@ func ReadE2EConfig(configPath string) (*E2EConfig, error) { //nolint:gocyclo
 
 	if gkeCredentials := os.Getenv("GKE_CREDENTIALS"); gkeCredentials != "" {
 		config.GkeCredentials = gkeCredentials
+	}
+
+	if gkeProjectID := os.Getenv("GKE_PROJECT_ID"); gkeProjectID != "" {
+		config.GkeProjectID = gkeProjectID
 	}
 
 	if certManagerVersion := os.Getenv("CERT_MANAGER_VERSION"); certManagerVersion != "" {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -258,8 +258,10 @@ var _ = BeforeSuite(func() {
 			b, err := templates.ReadFile(path.Join("templates", asset.Name()))
 			Expect(err).ToNot(HaveOccurred())
 
+			// Replace the placeholder in the file content with the actual value
+			content := strings.Replace(string(b), "${GKE_PROJECT_ID}", e2eCfg.GkeProjectID, -1)
 			gkeCluster := &gkev1.GKEClusterConfig{}
-			Expect(yaml.Unmarshal(b, gkeCluster)).To(Succeed())
+			Expect(yaml.Unmarshal([]byte(content), gkeCluster)).To(Succeed())
 
 			name := strings.TrimSuffix(asset.Name(), ".yaml")
 			generatedName := names.SimpleNameGenerator.GenerateName(name + "-")

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   description: "gke e2e basic cluster"
   labels: {}
   region: "us-west1"
-  projectID: "your-project-id"
+  projectID: "${GKE_PROJECT_ID}"
   kubernetesVersion: "1.28.4-gke.1083000"
   loggingService: ""
   monitoringService: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e tests locally are passing since the user is expected to change the `projectID` value in the `GKEClusterConfig` cluster template. However, e2e tests running daily in the GitHub Actions also need to replace that value, hence it was missing till now. This PR ensures the new `GKE_PROJECT_ID` var is created and passed to the cluster template later and replaces it with the actual value from GH secret `GKE_PROJECT_ID`. This should fix e2e tests currently broken
https://github.com/rancher/gke-operator/actions/workflows/e2e-latest-rancher.yaml

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Fixes: #264 
Follow-up to: https://github.com/rancher/gke-operator/pull/256

**Special notes for your reviewer**:
Tested the changes in my fork and tests are passing: https://github.com/furkatgofurov7/gke-operator/actions/runs/7472680816

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
- [ ] backport needed 
