### PR TITLE
chore: add ignore rule for dependabot updates on wrangler v2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,6 +22,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
   commit-message:
     prefix: ":seedling:"
   target-branch: "main"
@@ -38,6 +39,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.8"
@@ -54,6 +56,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add ignore rule for the recently updated wrangler, as we already did for other hosted providers https://github.com/rancher/eks-operator/pull/342.

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
