### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,15 +23,15 @@ jobs:
   publish-public:
     permissions:
       contents: read
-      id-token: write # this is important, it's how we authenticate with Vault
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
     - name: Read secrets
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/credentials docker_username | PUBLIC_REGISTRY_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/credentials docker_password | PUBLIC_REGISTRY_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials docker_username | PUBLIC_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials docker_password | PUBLIC_REGISTRY_PASSWORD ;
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
Updating the path for accessing to the secrets.
It was pointing to the wrong path

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
In order to retrieve the `dockerhub` secrets, the path has to be updated
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
