### PR TITLE
[v2.9] fix: Replace unapproved GH Actions with approved ones

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -11,4 +11,5 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
-    - uses: joelanford/go-apidiff@main
+    - name: Generate API diff
+      run: make apidiff

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,6 @@ jobs:
         with:
           go-version: 1.21.x
       - name: Analysis
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           args: -v
-          skip-pkg-cache: true

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         description: "Branch to use for GitHub action workflow"
         required: true
-        default: "main"
+        default: "release-v2.9"
       operator_path:
         description: "Operator github repo for the workflow"
         required: true
@@ -13,9 +13,9 @@ on:
       charts_ref:
         description: "Submit PR against the following rancher/charts branch (e.g. dev-v2.7)"
         required: true
-        default: "dev-v2.7"
+        default: "dev-v2.9"
       prev_operator_version:
-        description: "Previous operator version (e.g. 1.1.0-rc2)"
+        description: "Previous operator version (e.g. 1.2.0-rc.1)"
         required: true
         default: ""
       new_operator_version:
@@ -44,6 +44,7 @@ jobs:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: ${{github.event.inputs.operator_path}}
+          persist-credentials: false
       - name: Checkout rancher/charts
         uses: actions/checkout@v4
         with:
@@ -51,22 +52,30 @@ jobs:
           repository: rancher/charts
           ref: ${{github.event.inputs.charts_ref}}
           path: charts
-      - name: Run release script
+          persist-credentials: false
+      - name: Run release script # release script is responsible for git add/commit
         run: ./${{github.event.inputs.operator_path}}/.github/scripts/update-rancher-charts.sh ${{github.event.inputs.prev_operator_version}} ${{github.event.inputs.new_operator_version}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
         env:
           OPERATOR: ${{github.event.inputs.operator_path}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/charts.git
+          git push bot-fork HEAD:${{github.event.inputs.new_operator_version}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/charts
-          title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}'
-          body: |
-            Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}
-
-            Changelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.charts_ref}}
-          path: ./charts/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'charts',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_eks_operator}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.charts_ref}},
+              title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}',
+              body: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -5,13 +5,13 @@ on:
       ref:
         description: "Branch to use for GitHub action workflow"
         required: true
-        default: "main"
+        default: "release-v2.9"
       rancher_ref:
         description: "Submit PR against the following rancher/rancher branch (e.g. release/v2.7)"
         required: true
-        default: "release/v2.7"
+        default: "release/v2.9"
       new_version:
-        description: "New operator version (e.g. 1.1.0-rc2), don't include the 'v'"
+        description: "New operator version (e.g. 1.2.0-rc.1), don't include the 'v'"
         required: true
         default: ""
       operator_path:
@@ -33,6 +33,7 @@ jobs:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: ${{github.event.inputs.operator_path}}
+          persist-credentials: false
       - name: Checkout rancher/rancher
         uses: actions/checkout@v4
         with:
@@ -40,25 +41,33 @@ jobs:
           repository: rancher/rancher
           ref: ${{github.event.inputs.rancher_ref}}
           path: rancher
-      - uses: actions/setup-go@v4
+          persist-credentials: false
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
-      - name: Run release script
+      - name: Run release script # release script is responsible for git add/commit
         run: ./${{github.event.inputs.operator_path}}/.github/scripts/update-rancher-dep.sh ${{github.event.inputs.new_version}}
         env:
           OPERATOR: ${{github.event.inputs.operator_path}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/rancher.git
+          git push bot-fork HEAD:${{github.event.inputs.new_version}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/rancher
-          title: ' Update operator to v${{github.event.inputs.new_version}}'
-          body: |
-            Update operator to v${{github.event.inputs.new_version}}
-
-            Changelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_version}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.rancher_ref}}
-          path: ./rancher/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'rancher',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_version}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.rancher_ref}},
+              title: 'Update operator to v${{github.event.inputs.new_version}}',
+              body: 'Update operator to v${{github.event.inputs.new_version}}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_version}}\n\ncc @rancher/highlander'
+            })

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ GINKGO_VER := v2.17.3
 GINKGO_BIN := ginkgo
 GINKGO := $(BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
+GO_APIDIFF_VER := v0.8.2
+GO_APIDIFF_BIN := go-apidiff
+GO_APIDIFF := $(BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER)
+
 SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER)
@@ -172,3 +176,9 @@ docker-build-e2e:
 .PHOHY: delete-local-kind-cluster
 delete-local-kind-cluster: ## Delete the local kind cluster
 	kind delete cluster --name=$(CLUSTER_NAME)
+
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/release-v2.9)
+
+.PHONY: apidiff
+apidiff: $(GO_APIDIFF) ## Check for API differences
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Replace unapproved GH Actions with approved ones. To [enhance security](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), the 3rd-party GH Action used to install kind is pinned to a commit SHA. Note that dependabot will [update](https://github.com/dependabot/dependabot-core/issues/4691) both the commit SHA and the human-readable value next to it.

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/highlander/issues/89

**Special notes for your reviewer**:
- actions/setup-go has been updated to v5 to eliminate Node runtime version warnings
- Upon checkout, credentials are not being persisted since the git commands will occur on a different repo (bot's fork)

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
