### PR TITLE
[v2.7] fix: Replace unapproved GH Actions with approved ones

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -5,10 +5,11 @@ jobs:
   go-apidiff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
-        go-version: 1.19
-    - uses: joelanford/go-apidiff@main
+        go-version: 1.20.x
+    - name: Generate API diff
+      run: make apidiff

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,18 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.x
-      - uses: actions/cache@v3.3.1
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-build-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-go-${{ hashFiles('**/go.sum') }}
       - name: Build GKE operator binary
         run: make operator

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.x
       - name: Analysis

--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
       - name: Build binary

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build binary

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         description: "Branch to use for GitHub action workflow"
         required: true
-        default: "master"
+        default: "release-v2.7"
       operator_path:
         description: "Operator github repo for the workflow"
         required: true
@@ -15,7 +15,7 @@ on:
         required: true
         default: "dev-v2.7"
       prev_operator_version:
-        description: "Previous operator version (e.g. 1.1.0-rc2)"
+        description: "Previous operator version (e.g. 1.2.0-rc.1)"
         required: true
         default: ""
       new_operator_version:
@@ -39,34 +39,43 @@ jobs:
   create-rancher-charts-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: ${{github.event.inputs.operator_path}}
+          persist-credentials: false
       - name: Checkout rancher/charts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/charts
           ref: ${{github.event.inputs.charts_ref}}
           path: charts
+          persist-credentials: false
       - name: Run release script
         run: ./${{github.event.inputs.operator_path}}/.github/scripts/update-rancher-charts.sh ${{github.event.inputs.prev_operator_version}} ${{github.event.inputs.new_operator_version}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
         env:
           OPERATOR: ${{github.event.inputs.operator_path}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/charts.git
+          git push bot-fork HEAD:${{github.event.inputs.new_operator_version}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/charts
-          title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}'
-          body: |
-            Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}
-
-            Changelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.charts_ref}}
-          path: ./charts/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'charts',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_eks_operator}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.charts_ref}},
+              title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}',
+              body: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         description: "Branch to use for GitHub action workflow"
         required: true
-        default: "master"
+        default: "release-v2.7"
       rancher_ref:
         description: "Submit PR against the following rancher/rancher branch (e.g. release/v2.7)"
         required: true
@@ -28,37 +28,46 @@ jobs:
   create-rancher-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: ${{github.event.inputs.operator_path}}
+          persist-credentials: false
       - name: Checkout rancher/rancher
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/rancher
           ref: ${{github.event.inputs.rancher_ref}}
           path: rancher
-      - uses: actions/setup-go@v4
+          persist-credentials: false
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
       - name: Run release script
         run: ./${{github.event.inputs.operator_path}}/.github/scripts/update-rancher-dep.sh ${{github.event.inputs.new_version}}
         env:
           OPERATOR: ${{github.event.inputs.operator_path}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/rancher.git
+          git push bot-fork HEAD:${{github.event.inputs.new_version}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/rancher
-          title: ' Update operator to v${{github.event.inputs.new_version}}'
-          body: |
-            Update operator to v${{github.event.inputs.new_version}}
-
-            Changelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_version}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.rancher_ref}}
-          path: ./rancher/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'rancher',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_version}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.rancher_ref}},
+              title: 'Update operator to v${{github.event.inputs.new_version}}',
+              body: 'Update operator to v${{github.event.inputs.new_version}}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_version}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,19 +8,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.20.x
-    - uses: actions/cache@v3.3.1
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
     - name: Run make verify
       run: |
         make verify

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Requires upgrading to Go 1.21 but we can't do this before Rancher v2.7 gets updated 
+CVE-2023-45288

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n update && \
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN curl -sLf https://go.dev/dl/go1.20.7.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
+RUN curl -sLf https://go.dev/dl/go1.20.14.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
 # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
 RUN if [ "${ARCH}" == "arm64" ]; then \
         zypper -n install binutils-gold ; \

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ GINKGO_VER := v2.17.1
 GINKGO_BIN := ginkgo
 GINKGO := $(BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
+GO_APIDIFF_VER := v0.8.2
+GO_APIDIFF_BIN := go-apidiff
+GO_APIDIFF := $(BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER)
+
 SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER)
@@ -172,3 +176,9 @@ docker-build-e2e:
 .PHOHY: delete-local-kind-cluster
 delete-local-kind-cluster: ## Delete the local kind cluster
 	kind delete cluster --name=$(CLUSTER_NAME)
+
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/release-v2.7)
+
+.PHONY: apidiff
+apidiff: $(GO_APIDIFF) ## Check for API differences
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Replace unapproved GH Actions with approved ones. To [enhance security](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), the 3rd-party GH Action used to install kind is pinned to a commit SHA. Note that dependabot will [update](https://github.com/dependabot/dependabot-core/issues/4691) both the commit SHA and the human-readable value next to it.

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/highlander/issues/89

**Special notes for your reviewer**:
- actions/checkout has been updated to v4 to eliminate Node runtime version warnings
- actions/setup-go has been updated to v5 to eliminate Node runtime version warnings
 - Upon checkout, credentials are not being persisted since the git commands will occur on a different repo (bot's fork)


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
