### PR TITLE
WIP: [v2.9] Enhance logs

### DIFF
--- a/controller/gke-cluster-config-handler_test.go
+++ b/controller/gke-cluster-config-handler_test.go
@@ -763,6 +763,6 @@ var _ = Describe("createCluster", func() {
 
 		_, err := handler.create(gkeConfig)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("field [serviceAccount] must either be an empty string, 'default' or set to a valid email address for nodepool [test-node-pool] in non-nil cluster [test-cluster (test-cluster)]"))
+		Expect(err.Error()).To(Equal("field [serviceAccount] must either be an empty string, 'default' or set to a valid email address for nodepool [test-node-pool] in non-nil cluster [test-cluster (id: test-cluster)]"))
 	})
 })

--- a/controller/gke-cluster-config-handler_test.go
+++ b/controller/gke-cluster-config-handler_test.go
@@ -763,6 +763,6 @@ var _ = Describe("createCluster", func() {
 
 		_, err := handler.create(gkeConfig)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("field [serviceAccount] must either be an empty string, 'default' or set to a valid email address for nodepool [test-node-pool] in non-nil cluster [test-cluster]"))
+		Expect(err.Error()).To(Equal("field [serviceAccount] must either be an empty string, 'default' or set to a valid email address for nodepool [test-node-pool] in non-nil cluster [test-cluster (test-cluster)]"))
 	})
 })

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -14,8 +14,8 @@ import (
 
 // Errors
 const (
-	cannotBeNilError            = "field [%s] cannot be nil for non-import cluster [%s (%s)]"
-	cannotBeNilForNodePoolError = "field [%s] cannot be nil for nodepool [%s] in non-nil cluster [%s (%s)]"
+	cannotBeNilError            = "field [%s] cannot be nil for non-import cluster [%s (id: %s)]"
+	cannotBeNilForNodePoolError = "field [%s] cannot be nil for nodepool [%s] in non-nil cluster [%s (id: %s)]"
 )
 
 // Create creates an upstream GKE cluster.
@@ -181,13 +181,13 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 			return fmt.Errorf(cannotBeNilError, "nodePool.name", config.Spec.ClusterName, config.Name)
 		}
 		if nodeP[*np.Name] {
-			return fmt.Errorf("NodePool names %q must be unique within the cluster [%s (%s)] to avoid duplication", *np.Name, config.Spec.ClusterName, config.Name)
+			return fmt.Errorf("NodePool names %q must be unique within the cluster [%s (id: %s)] to avoid duplication", *np.Name, config.Spec.ClusterName, config.Name)
 		}
 		nodeP[*np.Name] = true
 
 		if np.Autoscaling != nil && np.Autoscaling.Enabled {
 			if np.Autoscaling.MinNodeCount < 1 || np.Autoscaling.MaxNodeCount < np.Autoscaling.MinNodeCount {
-				return fmt.Errorf("minNodeCount in the NodePool %s must be >= 1 and <= maxNodeCount within the cluster [%s (%s)]", *np.Name, config.Spec.ClusterName, config.Name)
+				return fmt.Errorf("minNodeCount in the NodePool %s must be >= 1 and <= maxNodeCount within the cluster [%s (id: %s)]", *np.Name, config.Spec.ClusterName, config.Name)
 			}
 		}
 	}
@@ -195,7 +195,7 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 	if config.Spec.CustomerManagedEncryptionKey != nil {
 		if config.Spec.CustomerManagedEncryptionKey.RingName == "" ||
 			config.Spec.CustomerManagedEncryptionKey.KeyName == "" {
-			return fmt.Errorf("ringName and keyName are required to enable boot disk encryption for Node Pools within the cluster [%s (%s)]", config.Spec.ClusterName, config.Name)
+			return fmt.Errorf("ringName and keyName are required to enable boot disk encryption for Node Pools within the cluster [%s (id: %s)]", config.Spec.ClusterName, config.Name)
 		}
 	}
 
@@ -207,7 +207,7 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 
 	for _, cluster := range operation.Clusters {
 		if cluster.Name == config.Spec.ClusterName {
-			return fmt.Errorf("cannot create cluster [%s (%s)] because a cluster in GKE exists with the same name, please delete and recreate with a different name", config.Spec.ClusterName, config.Name)
+			return fmt.Errorf("cannot create cluster [%s (id: %s)] because a cluster in GKE exists with the same name, please delete and recreate with a different name", config.Spec.ClusterName, config.Name)
 		}
 	}
 
@@ -247,7 +247,7 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 		return fmt.Errorf(cannotBeNilError, "privateClusterConfig", config.Spec.ClusterName, config.Name)
 	}
 	if config.Spec.PrivateClusterConfig.EnablePrivateEndpoint && !config.Spec.PrivateClusterConfig.EnablePrivateNodes {
-		return fmt.Errorf("private endpoint requires private nodes for cluster [%s (%s)]", config.Spec.ClusterName, config.Name)
+		return fmt.Errorf("private endpoint requires private nodes for cluster [%s (id: %s)]", config.Spec.ClusterName, config.Name)
 	}
 	if config.Spec.MasterAuthorizedNetworksConfig == nil {
 		return fmt.Errorf(cannotBeNilError, "masterAuthorizedNetworksConfig", config.Spec.ClusterName, config.Name)
@@ -302,7 +302,7 @@ func validateNodePoolCreateRequest(np *gkev1.GKENodePoolConfig, config *gkev1.GK
 
 	rxEmail := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-z]{2,}$`)
 	if np.Config.ServiceAccount != "" && np.Config.ServiceAccount != "default" && !rxEmail.MatchString(np.Config.ServiceAccount) {
-		return fmt.Errorf("field [%s] must either be an empty string, 'default' or set to a valid email address for nodepool [%s] in non-nil cluster [%s (%s)]", "serviceAccount", *np.Name, clusterName, config.Name)
+		return fmt.Errorf("field [%s] must either be an empty string, 'default' or set to a valid email address for nodepool [%s] in non-nil cluster [%s (id: %s)]", "serviceAccount", *np.Name, clusterName, config.Name)
 	}
 	return nil
 }

--- a/pkg/gke/update.go
+++ b/pkg/gke/update.go
@@ -46,7 +46,7 @@ func UpdateMasterKubernetesVersion(ctx context.Context, gkeClient services.GKECl
 		return NotChanged, nil
 	}
 
-	logrus.Infof("updating kubernetes version from %s to %s for cluster [%s (%s)]", utils.StringValue(upstreamSpec.KubernetesVersion), kubeVersion, config.Spec.ClusterName, config.Name)
+	logrus.Infof("updating kubernetes version from %s to %s for cluster [%s (id: %s)]", utils.StringValue(upstreamSpec.KubernetesVersion), kubeVersion, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.ClusterUpdate(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.UpdateClusterRequest{
@@ -107,7 +107,7 @@ func UpdateClusterAddons(ctx context.Context, gkeClient services.GKEClusterServi
 	}
 
 	if needsUpdate {
-		logrus.Infof("updating addon configuration (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.ClusterAddons, config.Spec.ClusterAddons, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating addon configuration (upstream: %+v; config: %+v) for cluster [%s (id: %s)]", upstreamSpec.ClusterAddons, config.Spec.ClusterAddons, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -172,7 +172,7 @@ func UpdateMasterAuthorizedNetworks(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating master authorized networks configuration (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.MasterAuthorizedNetworksConfig, config.Spec.MasterAuthorizedNetworksConfig, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating master authorized networks configuration (upstream: %+v; config: %+v) for cluster [%s (id: %s)]", upstreamSpec.MasterAuthorizedNetworksConfig, config.Spec.MasterAuthorizedNetworksConfig, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -217,7 +217,7 @@ func UpdateLoggingMonitoringService(
 		}
 	}
 	if needsUpdate {
-		logrus.Infof("updating logging (upstream: %s; config: %s) and monitoring (upstream: %s; config: %s) configuration for cluster [%s (%s)]", *upstreamSpec.MonitoringService, *config.Spec.MonitoringService, *upstreamSpec.LoggingService, *config.Spec.LoggingService, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating logging (upstream: %s; config: %s) and monitoring (upstream: %s; config: %s) configuration for cluster [%s (id: %s)]", *upstreamSpec.MonitoringService, *config.Spec.MonitoringService, *upstreamSpec.LoggingService, *config.Spec.LoggingService, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -243,7 +243,7 @@ func UpdateNetworkPolicyEnabled(
 	}
 
 	if *upstreamSpec.NetworkPolicyEnabled != *config.Spec.NetworkPolicyEnabled {
-		logrus.Infof("updating network policy (upstream: %v; config: %v) for cluster [%s (%s)]", *upstreamSpec.NetworkPolicyEnabled, *config.Spec.NetworkPolicyEnabled, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating network policy (upstream: %v; config: %v) for cluster [%s (id: %s)]", *upstreamSpec.NetworkPolicyEnabled, *config.Spec.NetworkPolicyEnabled, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetNetworkPolicy(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.SetNetworkPolicyRequest{
@@ -287,7 +287,7 @@ func UpdateLocations(
 
 	if !reflect.DeepEqual(locations, upstreamLocations) {
 		clusterUpdate.DesiredLocations = locations
-		logrus.Infof("updating locations (upstream: %v; config: %v) for cluster [%s (%s)]", upstreamLocations, locations, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating locations (upstream: %v; config: %v) for cluster [%s (id: %s)]", upstreamLocations, locations, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -325,7 +325,7 @@ func UpdateMaintenanceWindow(
 			},
 		}
 	}
-	logrus.Infof("updating maintenance window from %s to %s for cluster [%s (%s)]", *upstreamSpec.MaintenanceWindow, *config.Spec.MaintenanceWindow, config.Spec.ClusterName, config.Name)
+	logrus.Infof("updating maintenance window from %s to %s for cluster [%s (id: %s)]", *upstreamSpec.MaintenanceWindow, *config.Spec.MaintenanceWindow, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.SetMaintenancePolicy(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.SetMaintenancePolicyRequest{
@@ -351,7 +351,7 @@ func UpdateLabels(
 	if err != nil {
 		return NotChanged, err
 	}
-	logrus.Infof("updating cluster labels (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.Labels, config.Spec.Labels, config.Spec.ClusterName, config.Name)
+	logrus.Infof("updating cluster labels (upstream: %+v; config: %+v) for cluster [%s (id: %s)]", upstreamSpec.Labels, config.Spec.Labels, config.Spec.ClusterName, config.Name)
 	_, err = gkeClient.SetResourceLabels(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.SetLabelsRequest{
@@ -388,13 +388,13 @@ func UpdateNodePoolKubernetesVersionOrImageType(
 	needsUpdate := false
 	npVersion := utils.StringValue(nodePool.Version)
 	if npVersion != "" && utils.StringValue(upstreamNodePool.Version) != npVersion {
-		logrus.Infof("updating kubernetes version of node pool [%s] from %s to %s  on cluster [%s (%s)]", *nodePool.Name, npVersion, utils.StringValue(upstreamNodePool.Version), config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating kubernetes version of node pool [%s] from %s to %s  on cluster [%s (id: %s)]", *nodePool.Name, npVersion, utils.StringValue(upstreamNodePool.Version), config.Spec.ClusterName, config.Name)
 		updateRequest.NodeVersion = npVersion
 		needsUpdate = true
 	}
 	imageType := strings.ToLower(nodePool.Config.ImageType)
 	if imageType != "" && strings.ToLower(upstreamNodePool.Config.ImageType) != imageType {
-		logrus.Infof("updating image type of node pool [%s] from %s to %s on cluster [%s (%s)]", *nodePool.Name, imageType, upstreamNodePool.Config.ImageType, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating image type of node pool [%s] from %s to %s on cluster [%s (id: %s)]", *nodePool.Name, imageType, upstreamNodePool.Config.ImageType, config.Spec.ClusterName, config.Name)
 		updateRequest.ImageType = imageType
 		needsUpdate = true
 	}
@@ -430,7 +430,7 @@ func UpdateNodePoolSize(
 		return NotChanged, nil
 	}
 
-	logrus.Infof("updating size of node pool [%s] from %d to %d on cluster [%s (%s)]", *nodePool.Name, *upstreamNodePool.InitialNodeCount, *nodePool.InitialNodeCount, config.Spec.ClusterName, config.Name)
+	logrus.Infof("updating size of node pool [%s] from %d to %d on cluster [%s (id: %s)]", *nodePool.Name, *upstreamNodePool.InitialNodeCount, *nodePool.InitialNodeCount, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.SetSize(ctx,
 		NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 		&gkeapi.SetNodePoolSizeRequest{
@@ -478,7 +478,7 @@ func UpdateNodePoolAutoscaling(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating autoscaling config (upstream: %+v; config: %+v) of node pool [%s] on cluster [%s (%s)]", upstreamNodePool.Autoscaling, nodePool.Autoscaling, *nodePool.Name, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating autoscaling config (upstream: %+v; config: %+v) of node pool [%s] on cluster [%s (id: %s)]", upstreamNodePool.Autoscaling, nodePool.Autoscaling, *nodePool.Name, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetAutoscaling(ctx,
 			NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 			updateRequest)
@@ -519,7 +519,7 @@ func UpdateNodePoolManagement(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating management config (upstream: %+v, config: %+v) of node pool [%s] on cluster [%s (%s)]", upstreamNodePool.Management, nodePool.Management, *nodePool.Name, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating management config (upstream: %+v, config: %+v) of node pool [%s] on cluster [%s (id: %s)]", upstreamNodePool.Management, nodePool.Management, *nodePool.Name, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetManagement(ctx,
 			NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 			updateRequest)
@@ -553,7 +553,7 @@ func UpdateNodePoolConfig(
 		},
 	}
 
-	logrus.Infof("updating config for node pool [%s] on cluster [%s (%s)]", *nodePool.Name, config.Spec.ClusterName, config.Name)
+	logrus.Infof("updating config for node pool [%s] on cluster [%s (id: %s)]", *nodePool.Name, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.NodePoolUpdate(ctx,
 		NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 		updateRequest)

--- a/pkg/gke/update.go
+++ b/pkg/gke/update.go
@@ -388,13 +388,13 @@ func UpdateNodePoolKubernetesVersionOrImageType(
 	needsUpdate := false
 	npVersion := utils.StringValue(nodePool.Version)
 	if npVersion != "" && utils.StringValue(upstreamNodePool.Version) != npVersion {
-		logrus.Infof("updating kubernetes version from %s to %s on node pool [%s] on cluster [%s (%s)]", npVersion, utils.StringValue(upstreamNodePool.Version), *nodePool.Name, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating kubernetes version of node pool [%s] from %s to %s  on cluster [%s (%s)]", *nodePool.Name, npVersion, utils.StringValue(upstreamNodePool.Version), config.Spec.ClusterName, config.Name)
 		updateRequest.NodeVersion = npVersion
 		needsUpdate = true
 	}
 	imageType := strings.ToLower(nodePool.Config.ImageType)
 	if imageType != "" && strings.ToLower(upstreamNodePool.Config.ImageType) != imageType {
-		logrus.Infof("updating image type on node pool [%s] from %s to %s on cluster [%s (%s)]", imageType, upstreamNodePool.Config.ImageType, *nodePool.Name, config.Spec.ClusterName, config.Name)
+		logrus.Infof("updating image type of node pool [%s] from %s to %s on cluster [%s (%s)]", *nodePool.Name, imageType, upstreamNodePool.Config.ImageType, config.Spec.ClusterName, config.Name)
 		updateRequest.ImageType = imageType
 		needsUpdate = true
 	}

--- a/pkg/gke/update.go
+++ b/pkg/gke/update.go
@@ -8,11 +8,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	gkeapi "google.golang.org/api/container/v1"
+
 	gkev1 "github.com/rancher/gke-operator/pkg/apis/gke.cattle.io/v1"
 	"github.com/rancher/gke-operator/pkg/gke/services"
 	"github.com/rancher/gke-operator/pkg/utils"
-	"github.com/sirupsen/logrus"
-	gkeapi "google.golang.org/api/container/v1"
 )
 
 // Network Providers
@@ -45,7 +46,7 @@ func UpdateMasterKubernetesVersion(ctx context.Context, gkeClient services.GKECl
 		return NotChanged, nil
 	}
 
-	logrus.Infof("updating kubernetes version for cluster [%s]", config.Name)
+	logrus.Infof("updating kubernetes version from %s to %s for cluster [%s (%s)]", utils.StringValue(upstreamSpec.KubernetesVersion), kubeVersion, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.ClusterUpdate(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.UpdateClusterRequest{
@@ -106,7 +107,7 @@ func UpdateClusterAddons(ctx context.Context, gkeClient services.GKEClusterServi
 	}
 
 	if needsUpdate {
-		logrus.Infof("updating addon configuration for cluster [%s]", config.Name)
+		logrus.Infof("updating addon configuration (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.ClusterAddons, config.Spec.ClusterAddons, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -171,7 +172,7 @@ func UpdateMasterAuthorizedNetworks(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating master authorized networks configuration for cluster [%s]", config.Name)
+		logrus.Infof("updating master authorized networks configuration (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.MasterAuthorizedNetworksConfig, config.Spec.MasterAuthorizedNetworksConfig, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -216,7 +217,7 @@ func UpdateLoggingMonitoringService(
 		}
 	}
 	if needsUpdate {
-		logrus.Infof("updating logging and monitoring configuration for cluster [%s]", config.Name)
+		logrus.Infof("updating logging (upstream: %s; config: %s) and monitoring (upstream: %s; config: %s) configuration for cluster [%s (%s)]", *upstreamSpec.MonitoringService, *config.Spec.MonitoringService, *upstreamSpec.LoggingService, *config.Spec.LoggingService, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -242,7 +243,7 @@ func UpdateNetworkPolicyEnabled(
 	}
 
 	if *upstreamSpec.NetworkPolicyEnabled != *config.Spec.NetworkPolicyEnabled {
-		logrus.Infof("updating network policy for cluster [%s]", config.Name)
+		logrus.Infof("updating network policy (upstream: %v; config: %v) for cluster [%s (%s)]", *upstreamSpec.NetworkPolicyEnabled, *config.Spec.NetworkPolicyEnabled, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetNetworkPolicy(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.SetNetworkPolicyRequest{
@@ -286,7 +287,7 @@ func UpdateLocations(
 
 	if !reflect.DeepEqual(locations, upstreamLocations) {
 		clusterUpdate.DesiredLocations = locations
-		logrus.Infof("updating locations for cluster [%s]", config.Name)
+		logrus.Infof("updating locations (upstream: %v; config: %v) for cluster [%s (%s)]", upstreamLocations, locations, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.ClusterUpdate(ctx,
 			ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 			&gkeapi.UpdateClusterRequest{
@@ -324,7 +325,7 @@ func UpdateMaintenanceWindow(
 			},
 		}
 	}
-	logrus.Infof("updating maintenance window for cluster [%s]", config.Name)
+	logrus.Infof("updating maintenance window from %s to %s for cluster [%s (%s)]", *upstreamSpec.MaintenanceWindow, *config.Spec.MaintenanceWindow, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.SetMaintenancePolicy(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.SetMaintenancePolicyRequest{
@@ -350,7 +351,7 @@ func UpdateLabels(
 	if err != nil {
 		return NotChanged, err
 	}
-	logrus.Infof("updating cluster labels for cluster [%s]", config.Name)
+	logrus.Infof("updating cluster labels (upstream: %+v; config: %+v) for cluster [%s (%s)]", upstreamSpec.Labels, config.Spec.Labels, config.Spec.ClusterName, config.Name)
 	_, err = gkeClient.SetResourceLabels(ctx,
 		ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
 		&gkeapi.SetLabelsRequest{
@@ -387,13 +388,13 @@ func UpdateNodePoolKubernetesVersionOrImageType(
 	needsUpdate := false
 	npVersion := utils.StringValue(nodePool.Version)
 	if npVersion != "" && utils.StringValue(upstreamNodePool.Version) != npVersion {
-		logrus.Infof("updating kubernetes version on node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+		logrus.Infof("updating kubernetes version from %s to %s on node pool [%s] on cluster [%s (%s)]", npVersion, utils.StringValue(upstreamNodePool.Version), *nodePool.Name, config.Spec.ClusterName, config.Name)
 		updateRequest.NodeVersion = npVersion
 		needsUpdate = true
 	}
 	imageType := strings.ToLower(nodePool.Config.ImageType)
 	if imageType != "" && strings.ToLower(upstreamNodePool.Config.ImageType) != imageType {
-		logrus.Infof("updating image type on node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+		logrus.Infof("updating image type on node pool [%s] from %s to %s on cluster [%s (%s)]", imageType, upstreamNodePool.Config.ImageType, *nodePool.Name, config.Spec.ClusterName, config.Name)
 		updateRequest.ImageType = imageType
 		needsUpdate = true
 	}
@@ -429,7 +430,7 @@ func UpdateNodePoolSize(
 		return NotChanged, nil
 	}
 
-	logrus.Infof("updating size of node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+	logrus.Infof("updating size of node pool [%s] from %d to %d on cluster [%s (%s)]", *nodePool.Name, *upstreamNodePool.InitialNodeCount, *nodePool.InitialNodeCount, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.SetSize(ctx,
 		NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 		&gkeapi.SetNodePoolSizeRequest{
@@ -477,7 +478,7 @@ func UpdateNodePoolAutoscaling(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating autoscaling config of node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+		logrus.Infof("updating autoscaling config (upstream: %+v; config: %+v) of node pool [%s] on cluster [%s (%s)]", upstreamNodePool.Autoscaling, nodePool.Autoscaling, *nodePool.Name, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetAutoscaling(ctx,
 			NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 			updateRequest)
@@ -518,7 +519,7 @@ func UpdateNodePoolManagement(
 		needsUpdate = true
 	}
 	if needsUpdate {
-		logrus.Infof("updating management config of node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+		logrus.Infof("updating management config (upstream: %+v, config: %+v) of node pool [%s] on cluster [%s (%s)]", upstreamNodePool.Management, nodePool.Management, *nodePool.Name, config.Spec.ClusterName, config.Name)
 		_, err := gkeClient.SetManagement(ctx,
 			NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 			updateRequest)
@@ -552,7 +553,7 @@ func UpdateNodePoolConfig(
 		},
 	}
 
-	logrus.Infof("updating config for node pool [%s] on cluster [%s]", *nodePool.Name, config.Name)
+	logrus.Infof("updating config for node pool [%s] on cluster [%s (%s)]", *nodePool.Name, config.Spec.ClusterName, config.Name)
 	_, err := gkeClient.NodePoolUpdate(ctx,
 		NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, *nodePool.Name),
 		updateRequest)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/enhancement

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
1. Enhance the log to better understand updates happening in the cluster.
2. Use both clusterName and clusterID in the logs.

**Which issue(s) this PR fixes**
Issue #493 
Issue #494

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 


<details><summary>Sample Logs</summary>
<p>

```yaml
time="2024-06-10T11:26:40Z" level=info msg="Starting gke.cattle.io/v1, Kind=GKEClusterConfig controller"
time="2024-06-10T11:26:40Z" level=info msg="Starting /v1, Kind=Secret controller"
time="2024-06-10T11:27:41Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:27:41Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:27:42Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:28:12Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:28:42Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:29:12Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:29:43Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:30:13Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:30:44Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:31:14Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:31:44Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:32:15Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:32:46Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish creating"
time="2024-06-10T11:33:16Z" level=info msg="Cluster [pvala-gke (c-cf94j)] is running"
time="2024-06-10T11:39:33Z" level=info msg="updating autoscaling config (upstream: &{Enabled:false MaxNodeCount:0 MinNodeCount:0}; config: &{Enabled:true MaxNodeCount:3 MinNodeCount:1}) of node pool [dp] on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T11:39:35Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:40:06Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating"
time="2024-06-10T11:41:09Z" level=info msg="updating kubernetes version from 1.29.4-gke.1043002 to 1.29.4-gke.1670000 for cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T11:41:10Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:41:41Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:42:11Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:42:41Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:43:12Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:43:42Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:44:13Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:44:43Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:45:13Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:45:44Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:46:14Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:46:45Z" level=info msg="updating kubernetes version from 1.29.4-gke.1670000 to 1.29.4-gke.1043002 on node pool [dp] on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T11:46:46Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:47:17Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:47:47Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:48:18Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:48:48Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:49:18Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:49:49Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:50:19Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:50:50Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:51:20Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:51:50Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:52:21Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T11:52:51Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating"
time="2024-06-10T12:10:19Z" level=info msg="updating image type on node pool [ubuntu_containerd] from COS_CONTAINERD to dp on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:10:21Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:10:53Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:11:24Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:11:54Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:12:24Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:12:55Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:13:25Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:13:56Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:14:26Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:14:57Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:15:27Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:15:57Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:16:28Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating"
time="2024-06-10T12:43:53Z" level=info msg="updating logging (upstream: monitoring.googleapis.com/kubernetes; config: none) and monitoring (upstream: logging.googleapis.com/kubernetes; config: none) configuration for cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:43:56Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:44:27Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:44:57Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:45:28Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:45:58Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:46:29Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:46:59Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:47:29Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:48:00Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:48:30Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:49:01Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:49:31Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:50:01Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:50:32Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:51:02Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:51:33Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating"
time="2024-06-10T12:55:35Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:36Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:37Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:37Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:38Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:39Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:39Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:40Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:41Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:41Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:44Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:55:51Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:56:02Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:56:23Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: cluster [c-cf94j] cannot have multiple nodepools with name dp, requeuing"
time="2024-06-10T12:56:43Z" level=info msg="updating size of node pool [dp] from 1 to 2 on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:56:46Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:56:53Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:57:23Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:57:54Z" level=info msg="waiting for cluster [pvala-gke (c-cf94j)] to finish updating"
time="2024-06-10T12:58:24Z" level=info msg="updating management config (upstream: &{AutoRepair:true AutoUpgrade:true}, config: &{AutoRepair:false AutoUpgrade:false}) of node pool [dp] on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:58:26Z" level=info msg="updating management config (upstream: &{AutoRepair:true AutoUpgrade:true}, config: &{AutoRepair:false AutoUpgrade:false}) of node pool [dp] on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:58:27Z" level=error msg="error syncing 'cattle-global-data/c-cf94j': handler gke-controller: googleapi: Error 400: Cluster is running incompatible operation operation-1718024305921-fd4f65ea-7da5-4d36-a166-f619a83fb205.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.RequestInfo\",\n    \"requestId\": \"0xbc082b8846774fe9\"\n  }\n]\n, failedPrecondition, requeuing"
time="2024-06-10T12:58:27Z" level=info msg="updating management config (upstream: &{AutoRepair:true AutoUpgrade:true}, config: &{AutoRepair:false AutoUpgrade:false}) of node pool [dp] on cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T12:58:29Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating"
time="2024-06-10T12:58:30Z" level=info msg="cluster [pvala-gke (c-cf94j)] finished updating
time="2024-06-10T13:33:54Z" level=info msg="updating addon configuration (upstream: &{HTTPLoadBalancing:true HorizontalPodAutoscaling:true NetworkPolicyConfig:false}; config: &{HTTPLoadBalancing:true HorizontalPodAutoscaling:false NetworkPolicyConfig:true}) for cluster [pvala-gke (c-cf94j)]"
time="2024-06-10T13:48:18Z" level=info msg="importing cluster [auto-gke-hp-ci-ohpmr (c-wkf4l)]"
time="2024-06-10T14:05:52Z" level=info msg="cluster [auto-gke-hp-ci-ohpmr (c-wkf4l)] is imported, will not delete GKE cluster"
time="2024-06-10T14:05:59Z" level=info msg="removing cluster [pvala-gke (c-cf94j)] from project container-project-qa, region/zone us-central1-c"
```

</p>
</details> 