### PR TITLE
Fix e2e workflow

### DIFF
--- a/.github/workflows/e2e-branch.yaml
+++ b/.github/workflows/e2e-branch.yaml
@@ -89,7 +89,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.3.3
         with:
-          name: ci-artifacts
+          name: ci-artifacts-${{ env.BRANCH }}
           path: _artifacts
           if-no-files-found: ignore
       - name: Send failed status to slack

--- a/.github/workflows/e2e-branch.yaml
+++ b/.github/workflows/e2e-branch.yaml
@@ -35,21 +35,25 @@ jobs:
         run: |
           TAG="v0.0.0"
           COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
+          COMMIT=`git rev-parse HEAD`
+          COMMIT_SHORT=`git rev-parse --short HEAD`
           echo "operator_tag=$TAG" >> $GITHUB_OUTPUT
           echo "commit_date=$COMMITDATE" >> $GITHUB_OUTPUT
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+          echo "commit_short=$COMMIT_SHORT" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ${{ env.REPO }}
           tags: |
-            type=sha,format=short,prefix=${{ steps.export_tag.outputs.operator_tag }}-
+            type=raw,value=${{ steps.export_tag.outputs.operator_tag }}-${{ steps.export_tag.outputs.commit_short }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3.2.0
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       - name: Build and push image
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
@@ -62,7 +66,7 @@ jobs:
           build-args: |
             TAG=${{ steps.export_tag.outputs.operator_tag }}
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
-            COMMIT=${{ github.sha }}
+            COMMIT=${{ steps.export_tag.outputs.commit }}
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -33,13 +33,3 @@ jobs:
       GKE_CREDENTIALS: ${{ secrets.GKE_CREDENTIALS }}
       GKE_PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  e2e-test-v2_7:
-    if: ${{ always() }}
-    needs: [ e2e-test-main, e2e-test-v2_9, e2e-test-v2_8 ]
-    uses: ./.github/workflows/e2e-branch.yaml
-    with:
-      branch: release-v2.7
-    secrets:
-      GKE_CREDENTIALS: ${{ secrets.GKE_CREDENTIALS }}
-      GKE_PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Fixed tagging of the images built by CI that are used for e2e tests. Currently, the image tag is always using the commit of the `main` branch (as that branch is used to run the e2e workflow for all releases we maintain) regardless of the branch for which the e2e tests are executing. After this change, the tag will use the commit of each branch.

Also removed the e2e tests for 2.7 as this is going into maintenance mode.

Example test run: https://github.com/yiannistri/gke-operator/actions/runs/9549828162

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
