### PR TITLE
[v2.9] Drop support for Kubernetes v1.25 and v1.26

### DIFF
--- a/controller/gke-cluster-config-handler_test.go
+++ b/controller/gke-cluster-config-handler_test.go
@@ -104,7 +104,7 @@ var _ = Describe("buildUpstreamClusterState", func() {
 	BeforeEach(func() {
 		clusterState = &gkeapi.Cluster{
 			Name:                 "test-cluster",
-			CurrentMasterVersion: "1.25.13-gke.200",
+			CurrentMasterVersion: "1.28.10-gke.1089000",
 			Zone:                 "test-east1",
 			Locations:            []string{"test-east1-a", "test-east1-b", "test-east1-c"},
 			Endpoint:             "https://test.com",
@@ -149,7 +149,7 @@ var _ = Describe("buildUpstreamClusterState", func() {
 				{
 					Name:             "np-tes1",
 					InitialNodeCount: 1,
-					Version:          "1.25.13-gke.200",
+					Version:          "1.28.10-gke.1089000",
 					MaxPodsConstraint: &gkeapi.MaxPodsConstraint{
 						MaxPodsPerNode: 110,
 					},
@@ -258,7 +258,7 @@ var _ = Describe("importCluster", func() {
 
 		clusterState = &gkeapi.Cluster{
 			Name:                 "test-cluster",
-			CurrentMasterVersion: "1.25.13-gke.200",
+			CurrentMasterVersion: "1.28.10-gke.1089000",
 			Zone:                 "test-east1",
 			Locations:            []string{"test-east1-a", "test-east1-b", "test-east1-c"},
 			Endpoint:             "https://test.com",
@@ -303,7 +303,7 @@ var _ = Describe("importCluster", func() {
 				{
 					Name:             "np-tes1",
 					InitialNodeCount: 1,
-					Version:          "1.25.13-gke.200",
+					Version:          "1.28.10-gke.1089000",
 					MaxPodsConstraint: &gkeapi.MaxPodsConstraint{
 						MaxPodsPerNode: 110,
 					},
@@ -434,7 +434,7 @@ var _ = Describe("createCluster", func() {
 
 		clusterState = &gkeapi.Cluster{
 			Name:                 "test-cluster",
-			CurrentMasterVersion: "1.25.13-gke.200",
+			CurrentMasterVersion: "1.28.10-gke.1089000",
 			Zone:                 "test-east1",
 			Locations:            []string{"test-east1-a", "test-east1-b", "test-east1-c"},
 			Endpoint:             "https://test.com",
@@ -479,7 +479,7 @@ var _ = Describe("createCluster", func() {
 				{
 					Name:             "np-test1",
 					InitialNodeCount: 1,
-					Version:          "1.25.13-gke.200",
+					Version:          "1.28.10-gke.1089000",
 					MaxPodsConstraint: &gkeapi.MaxPodsConstraint{
 						MaxPodsPerNode: 110,
 					},

--- a/pkg/gke/delete_test.go
+++ b/pkg/gke/delete_test.go
@@ -14,7 +14,7 @@ var _ = Describe("RemoveCluster", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		k8sVersion         = "1.25.12-gke.200"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"
@@ -111,7 +111,7 @@ var _ = Describe("RemoveNodePool", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		k8sVersion         = "1.25.12-gke.200"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"

--- a/pkg/gke/update_test.go
+++ b/pkg/gke/update_test.go
@@ -14,8 +14,8 @@ var _ = Describe("UpdateMasterKubernetesVersion", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		oldVersion         = "1.25.12-gke.200"
-		k8sVersion         = "1.26.8-gke.110"
+		oldVersion         = "1.27.13-gke.3013000"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"
@@ -100,7 +100,7 @@ var _ = Describe("UpdateClusterAddons", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		k8sVersion         = "1.26.8-gke.110"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"
@@ -201,7 +201,7 @@ var _ = Describe("UpdateMasterAuthorizedNetworks", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		k8sVersion         = "1.26.8-gke.110"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"
@@ -314,7 +314,7 @@ var _ = Describe("UpdateNodePoolAutoscaling", func() {
 	var (
 		mockController     *gomock.Controller
 		clusterServiceMock *mock_services.MockGKEClusterService
-		k8sVersion         = "1.26.8-gke.110"
+		k8sVersion         = "1.28.10-gke.1089000"
 		clusterIpv4Cidr    = "10.42.0.0/16"
 		networkName        = "test-network"
 		subnetworkName     = "test-subnetwork"


### PR DESCRIPTION
Issue: https://github.com/rancher/gke-operator/issues/526

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
