### PR TITLE
[v2.9] fix: Bump Go version to fix CVE-2024-24790

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n update && \
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go CGO_ENABLED=0 PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN curl -sLf https://go.dev/dl/go1.22.3.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
+RUN curl -sLf https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
 # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
 RUN if [ "${ARCH}" == "arm64" ]; then \
         zypper -n install binutils-gold ; \


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bumped Go version to fix CVE-2024-24790.

Fixes https://github.com/rancher/gke-operator/issues/532

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
