### PR TITLE
[v2.7] ci: Add goreleaser config and update release workflow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,25 +20,6 @@ steps:
     - pull_request
     - tag
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-      - sha256
-    checksum_file: CHECKSUMsum-amd64.txt
-    checksum_flatten: true
-    files:
-      - "dist/artifacts/*"
-  when:
-    ref:
-      - refs/head/master
-      - refs/tags/*
-    event:
-      - tag
-
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -91,25 +72,6 @@ steps:
     - push
     - pull_request
     - tag
-
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-      - sha256
-    checksum_file: CHECKSUMsum-arm64.txt
-    checksum_flatten: true
-    files:
-      - "dist/artifacts/*"
-  when:
-    ref:
-      - refs/head/master
-      - refs/tags/*
-    event:
-      - tag
 
 - name: docker-publish
   image: plugins/docker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,15 +15,12 @@ on:
 #   - PUBLIC_REGISTRY_USERNAME
 #   - PUBLIC_REGISTRY_PASSWORD
 
-permissions:
-  contents: read
-
 jobs:
-  publish-public:
+  release:
     permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-22.04
+      contents: write # required for creating GH release
+      id-token: write # required for reading vault secrets
+    runs-on: ubuntu-latest
     steps:
     - name: Read secrets
       uses: rancher-eio/read-vault-secrets@main
@@ -44,15 +41,40 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.ref_name}}
-    - name: Build operator binary
-      run: |
-        make operator
+        fetch-depth: 0
+        ref: ${{ github.ref_name }}     
     - name: Build and push all image variations
       run: |
+        make operator 
         make image-push
         TAG="${TAG}-amd64" TARGET_PLATFORMS=linux/amd64 make image-push
         TAG="${TAG}-arm64" TARGET_PLATFORMS=linux/arm64 make image-push
       env:
         TAG: ${{ github.ref_name }}
         REPO: ${{ vars.PUBLIC_REGISTRY }}/${{ vars.PUBLIC_REGISTRY_REPO }}
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for creating GH release
+      id: goreleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        distribution: goreleaser
+        version: "~> v2"
+        args: release --clean --verbose
+    - name: Upload charts to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for updating GH release
+        TAG: ${{ github.ref_name }} # image tag to be referenced in `values.yaml` of the Helm chart release
+      run: |
+        version=$(echo '${{ steps.goreleaser.outputs.metadata }}' | jq -r '.version')
+        echo "Publishing helm charts (version: $version)"
+
+        # Both version and appVersion are set to the same value in the Chart.yaml (excluding the 'v' prefix)
+        CHART_VERSION=$version GIT_TAG=$version make charts
+
+        for f in $(find bin/ -name '*.tgz'); do
+          echo "Uploading $f to GitHub release $TAG"
+          gh release upload $TAG $f
+        done
+        echo "Charts successfully uploaded to GitHub release $TAG"
+    

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 dist/
 vendor/
 .dapper
+_artifacts/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,27 @@
+version: 2
+
+project_name: gke-operator
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    binary: gke-operator
+
+release:
+  prerelease: auto
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,3 @@
 # Requires upgrading to Go 1.21 but we can't do this before Rancher v2.7 gets updated 
 CVE-2023-45288
+CVE-2024-24790


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Up until recently, creating a new GitHub release (and associated artifacts) when a new tag was created, was being done using Drone CI. Now that Drone CI has been deprecated, there is a GitHub Actions workflow that is responsible for doing this. In fact, most of the work is delegated to goreleaser which is being invoked as part of that workflow.

Cherry pick of the commit of https://github.com/rancher/gke-operator/pull/540

**Which issue(s) this PR fixes**
Issue #538

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
