### PR TITLE
ci: Show dropdown options for selecting target branch

### DIFF
--- a/.github/scripts/update-rancher-charts.sh
+++ b/.github/scripts/update-rancher-charts.sh
@@ -34,11 +34,14 @@ find ./packages/rancher-${OPERATOR}/ -type f -exec sed -i -e "s/version: ${PREV_
 find ./packages/rancher-${OPERATOR}/ -type f -exec sed -i -e "/doNotRelease: false/d" {} \;
 
 if [ "${REPLACE}" == "true" ] && grep -q "rancher-${OPERATOR}:" release.yaml; then
+    # replace previous with new version
     sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_OPERATOR_VERSION}/${NEW_CHART_VERSION}+up${NEW_OPERATOR_VERSION}/g" release.yaml
 else
     if grep -q "rancher-${OPERATOR}:" release.yaml; then
+        # append new version below previous version
         sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_OPERATOR_VERSION}/${PREV_CHART_VERSION}+up${PREV_OPERATOR_VERSION}\n  - ${NEW_CHART_VERSION}+up${NEW_OPERATOR_VERSION}/g" release.yaml
     else
+        # add new version to release.yaml
         cat <<< "
 rancher-${OPERATOR}:
 - ${PREV_CHART_VERSION}+up${PREV_OPERATOR_VERSION}

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -2,71 +2,89 @@ name: Update GKE operator in rancher/charts
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch to use for GitHub action workflow"
-        required: true
-        default: "main"
-      operator_path:
-        description: "Operator github repo for the workflow"
-        required: true
-        default: "gke-operator"
       charts_ref:
-        description: "Submit PR against the following rancher/charts branch (e.g. dev-v2.7)"
+        description: 'Target rancher/charts branch against which a PR will be opened'
         required: true
-        default: "dev-v2.7"
-      prev_operator_version:
-        description: "Previous operator version (e.g. 1.1.0-rc2)"
+        default: "dev-v2.9"
+        type: choice
+        options:
+          - "dev-v2.7"
+          - "dev-v2.8"
+          - "dev-v2.9"
+      previous_operator_version:
+        description: 'Previous operator version (e.g. 1.1.0-rc2)'
         required: true
         default: ""
       new_operator_version:
-        description: "New operator version"
+        description: 'New operator version'
         required: true
         default: ""
-      prev_chart:
-        description: "Previous Rancher Chart version (e.g. 101.1.0)"
+      previous_chart_version:
+        description: 'Previous Rancher chart version (e.g. 101.1.0)'
         required: true
         default: ""
-      new_chart:
-        description: "New Rancher Chart version"
+      new_chart_version:
+        description: 'New Rancher chart version'
         required: true
         default: ""
       should_replace:
-        description: "Should the old operator version be replaced/removed? (e.g. true in case of release candidate bumps)"
+        description: 'Should the old operator version be replaced/removed? (e.g. true in case of release candidate bumps)'
         required: true
-        default: "true"
+        default: true
+        type: boolean
+
+env:
+  OPERATOR: gke-operator
 
 jobs:
   create-rancher-charts-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout operator repository to invoke release script
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-          ref: ${{github.event.inputs.ref}}
-          path: ${{github.event.inputs.operator_path}}
+          path: ${{ env.OPERATOR }}
       - name: Checkout rancher/charts
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-          repository: rancher/charts
-          ref: ${{github.event.inputs.charts_ref}}
+          repository: ${{ github.repository_owner }}/charts
+          ref: ${{ github.event.inputs.charts_ref }}
           path: charts
+      - name: Set env variables
+        run: |
+          echo "TIMESTAMP=$(date +'%s')" >> $GITHUB_ENV
+          CHARTS_REF=${{ github.event.inputs.charts_ref }}
+          echo "VERSION=${CHARTS_REF: -4}" >> $GITHUB_ENV
+      - name: Create new charts branch
+        working-directory: charts
+        run: |
+          git checkout -b ${{ env.OPERATOR }}-$VERSION-$TIMESTAMP
       - name: Run release script
-        run: ./${{github.event.inputs.operator_path}}/.github/scripts/update-rancher-charts.sh ${{github.event.inputs.prev_operator_version}} ${{github.event.inputs.new_operator_version}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
-        env:
-          OPERATOR: ${{github.event.inputs.operator_path}}
-      - name: Set timestamp
-        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
-      - name: Create PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{secrets.CI_BOT_TOKEN}}
-          script: |
-            github.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}',
-              head: 'highlander-ci-bot/charts:${{github.event.inputs.new_version}}-$TIMESTAMP',
-              base: ${{github.event.inputs.charts_ref}},
-              body: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
-            })
+        run: |
+          ./${{ env.OPERATOR }}/.github/scripts/update-rancher-charts.sh \
+          ${{ github.event.inputs.previous_operator_version }} \
+          ${{ github.event.inputs.new_operator_version }} \
+          ${{ github.event.inputs.previous_chart_version }} \
+          ${{ github.event.inputs.new_chart_version }} \
+          ${{ github.event.inputs.should_replace }}
+      - name: Create remote branch
+        working-directory: charts
+        run: |
+          git remote add bot https://github.com/highlander-ci-bot/charts
+          git push bot ${{ env.OPERATOR }}-$VERSION-$TIMESTAMP
+          git diff .
+      # - name: Create PR
+      #   uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      #   with:
+      #     github-token: ${{secrets.CI_BOT_TOKEN}}
+      #     script: |
+      #       github.pulls.create({
+      #         owner: context.repo.owner,
+      #         repo: 'charts',
+      #         title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}',
+      #         head: 'highlander-ci-bot/charts:${{github.event.inputs.new_version}}-$TIMESTAMP',
+      #         base: ${{github.event.inputs.charts_ref}},
+      #         body: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
+      #       })


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Updated workflow to show dropdown options for selecting target branch and tested the release script. Note that this is not yet 100% complete as the last step is to create a PR from the bot's branch. However, merging this PR will allow us to test the creation of the remote branch (which requires bot token access).

After merging this PR:
- a user can select the target 'rancher/charts' branch to create a PR against
- a user specifies old/new version of chart and operator and whether the new version replaces the old one
- the release script will run and update a local branch with the requested changes

Still left to do:
- push local branch into bot's remote
- create PR from bot's remote

**Which issue(s) this PR fixes**
Issue #96 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
