### PR TITLE
ci: Create PR against rancher/charts

### DIFF
--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -76,21 +76,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
         working-directory: charts
         run: |
-          git remote -v
           git remote add bot https://${GITHUB_TOKEN}@github.com/highlander-ci-bot/charts.git
-          git remote
           git push bot HEAD:${{ env.OPERATOR }}-$VERSION-$TIMESTAMP
-          git diff .
-      # - name: Create PR
-      #   uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      #   with:
-      #     github-token: ${{secrets.CI_BOT_TOKEN}}
-      #     script: |
-      #       github.pulls.create({
-      #         owner: context.repo.owner,
-      #         repo: 'charts',
-      #         title: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}',
-      #         head: 'highlander-ci-bot/charts:${{github.event.inputs.new_version}}-$TIMESTAMP',
-      #         base: ${{github.event.inputs.charts_ref}},
-      #         body: 'Update ${{github.event.inputs.operator_path}} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{github.event.inputs.operator_path}}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
-      #       })
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'charts',
+              title: '[${{ github.event.inputs.charts_ref }}] rancher-${{ env.OPERATOR }} ${{ github.event.inputs.new_chart_version }}+up${{ github.event.inputs.new_operator_version }} update',
+              head: 'highlander-ci-bot/charts:${{ env.OPERATOR }}-$VERSION-$TIMESTAMP',
+              base: ${{ github.event.inputs.charts_ref }},
+              body: 'Update ${{ env.OPERATOR }} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{ env.OPERATOR }}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
+            })


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Once this PR gets merged, whenever a user invokes this workflow, a new PR will be opened against the rancher/charts with the changes necessary to update the operator version.

**Which issue(s) this PR fixes**
Issue #96 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
