### PR TITLE
ci: Use `gh` cli to create PR

### DIFF
--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -79,15 +79,12 @@ jobs:
           git remote add bot https://${GITHUB_TOKEN}@github.com/highlander-ci-bot/charts.git
           git push bot HEAD:${{ env.OPERATOR }}-$VERSION-$TIMESTAMP
       - name: Create PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{secrets.CI_BOT_TOKEN}}
-          script: |
-            github.pulls.create({
-              owner: 'rancher',
-              repo: 'charts',
-              title: '[${{ github.event.inputs.charts_ref }}] rancher-${{ env.OPERATOR }} ${{ github.event.inputs.new_chart_version }}+up${{ github.event.inputs.new_operator_version }} update',
-              head: 'highlander-ci-bot/charts:${{ env.OPERATOR }}-$VERSION-$TIMESTAMP',
-              base: ${{ github.event.inputs.charts_ref }},
-              body: 'Update ${{ env.OPERATOR }} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{ env.OPERATOR }}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander'
-            })
+        env:
+          GH_TOKEN: ${{secrets.CI_BOT_TOKEN}}
+        run: |
+          gh pr create \
+            --base "${{ github.event.inputs.charts_ref }}" \
+            --head "highlander-ci-bot:${{ env.OPERATOR }}-$VERSION-$TIMESTAMP" \
+            --title "[${{ github.event.inputs.charts_ref }}] rancher-${{ env.OPERATOR }} ${{ github.event.inputs.new_chart_version }}+up${{ github.event.inputs.new_operator_version }} update" \
+            --body "Update ${{ env.OPERATOR }} to v${{github.event.inputs.new_operator_version}}\n\nChangelog: https://github.com/rancher/${{ env.OPERATOR }}/releases/tag/v${{github.event.inputs.new_operator_version}}\n\ncc @rancher/highlander"
+


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Use the `gh` cli to create a PR. The equivalent GH action that is currently used [is failing](https://github.com/rancher/gke-operator/actions/runs/9841742752).

**Which issue(s) this PR fixes**
Issue #96 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
