### PR TITLE
Propagate debug log flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 vendor/
 .dapper
 _artifacts/
+.envrc

--- a/charts/gke-operator/templates/deployment.yaml
+++ b/charts/gke-operator/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       - name: rancher-gke-operator
         image: '{{ template "system_default_registry" $ }}{{ $.Values.gkeOperator.image.repository }}:{{ $.Values.gkeOperator.image.tag }}'
         imagePullPolicy: IfNotPresent
+        args: ["-debug={{ .Values.gkeOperator.debug | default false }}"]
         env:
         - name: HTTP_PROXY
           value: {{ .Values.httpProxy }}

--- a/charts/gke-operator/values.yaml
+++ b/charts/gke-operator/values.yaml
@@ -6,6 +6,7 @@ gkeOperator:
   image:
     repository: rancher/gke-operator
     tag: v0.0.0
+  debug: false
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Propagates the debug log flag so that it can be set on the gke-operator's helm chart. By default, it is set to false.

**Which issue(s) this PR fixes**
Issue #511 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [x] backport needed 
