### PR TITLE
[v2.8] fix: Update e2e k8s version

### DIFF
--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   labels: {}
   region: "us-west1"
   projectID: "${GKE_PROJECT_ID}"
-  kubernetesVersion: "1.28.12-gke.1179000"
+  kubernetesVersion: "1.28.14-gke.1099000"
   loggingService: ""
   monitoringService: ""
   enableKubernetesAlpha: false
@@ -23,7 +23,7 @@ spec:
       labels: {}
     initialNodeCount: 1
     maxPodsConstraint: 110
-    version: "1.28.12-gke.1179000"
+    version: "1.28.14-gke.1099000"
     management:
       autoRepair: true
       autoUpgrade: true


### PR DESCRIPTION
(cherry picked from commit 08014af8f5b8d34b8ccf13f8e9b2a5c224d97e43)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The current version of Kubernetes used for e2e tests is no longer supported.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
