### PR TITLE
[v2.7] Bump image version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.ref_name }}     
+        ref: ${{ github.ref_name }}
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        check-latest: true
     - name: Build and push all image variations
       run: |
         make operator 

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,9 +1,11 @@
 name: Scan
 on:
   pull_request:
+    branches:
+      - release-v2.7
   push:
     branches:
-      - master
+      - release-v2.7
     tags:
       - "v*"
 jobs:
@@ -14,8 +16,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Build binary
-        run: make build
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+      - name: Build operator
+        run: make operator
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2.9.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,4 @@
 # Requires upgrading to Go 1.21 but we can't do this before Rancher v2.7 gets updated 
 CVE-2023-45288
 CVE-2024-24790
+CVE-2024-34156

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.suse.com/bci/bci-base:15.5 AS builder
+FROM registry.suse.com/bci/bci-base:15.6 AS builder
 RUN sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd
 RUN useradd --uid 1007 gke-operator
 
-FROM registry.suse.com/bci/bci-micro:15.5
+FROM registry.suse.com/bci/bci-micro:15.6
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/shadow /etc/shadow
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump base image version to 15.6. Also updated release and scan workflows to use the same version of Go, which is the one specified in go.mod.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
