### PR TITLE
ci: Use Go 1.23 to build binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version: '1.23'
         check-latest: true
     - name: Build and push all image variations
       run: |

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.23'
           check-latest: true
       - name: Build operator
         run: make operator

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,0 @@
-# Requires upgrading to Go 1.21 but we can't do this before Rancher v2.7 gets updated 
-CVE-2023-45288
-CVE-2024-24790
-CVE-2024-34156


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

We bump the version of the Go compiler used to build the operator itself in order to protect from any vulnerabilities that are present in older versions of the compiler. Note that we intentionally do not bump the version of the Go module as it's imported by Rancher 2.7.

**Special notes for your reviewer**:

The list of CVEs addressed:
- CVE-2023-45288
- CVE-2024-24790
- CVE-2024-34156

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
