### PR TITLE
[v2.9] ci: Fix trivy action timeout

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,5 +1,6 @@
 name: Scan
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - release-v2.9
@@ -35,7 +36,10 @@ jobs:
           push: false
           file: package/Dockerfile
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           image-ref: "ghcr.io/rancher/gke-operator:${{ github.sha }}"
           format: "table"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

We frequently get CI failures when scanning with trivy because there have been too many requests to download the vulnerability db from the rancher org (because many of its repos are using it).

This PR updates the Scan workflow to include additional repositories to be used if trivy fails to retrieve the vulnerability db from the primary source.

**Which issue(s) this PR fixes**
Issue #703 

**Special notes for your reviewer**:

Source for fix: https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10884984

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
