### PR TITLE
Update and remove deprecated config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,4 +19,3 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: -v
-          skip-pkg-cache: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Analysis
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,12 @@
 run:
   timeout: 5m
   go: "1.20"
-  skip-files:
-    - "zz_generated_*"
-  skip-dirs:
-    - pkg/generated
   tests: false
   allow-parallel-runners: true
 
 output:
-  format: github-actions
+  formats:
+    - format: github-actions
 
 linters:
   disable-all: true
@@ -88,3 +85,7 @@ issues:
     - revive
     text: "var-naming: don't use an underscore in package name"
     path: 'mock(\w+)/doc.go$'
+  exclude-dirs:
+    - pkg/generated
+  exclude-files:
+    - "zz_generated_*"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.20"
+  go: "1.23"
   tests: false
   allow-parallel-runners: true
 


### PR DESCRIPTION
### Updates
- `skip-pkg-cache` is removed in golangci lint.  [Reference](https://github.com/golangci/golangci-lint-action/tree/0bc16cda6e51961f4eb7c2ee2a92b0a4a5ddfd4b?tab=readme-ov-file#compatibility)
- `run.skip-dirs` is deprecated and is replaced by `issues.exclude-dirs` . [Reference](https://github.com/golangci/golangci-lint/pull/4509)

### Issue
- https://github.com/rancher/gke-operator/actions/runs/13360664115/job/37309809267?pr=829