### PR TITLE
[backport] Ignore semver/v3 in dependabot due to breaking integration 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,6 +25,8 @@ updates:
     - dependency-name: "github.com/rancher/wrangler/v3"
     # Ignore rancher apis
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "main"
@@ -46,6 +48,8 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     # Ignore Google API version, due it is breaking integration
     - dependency-name: "google.golang.org/api"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.11"
@@ -67,6 +71,8 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     # Ignore Google API version, due it is breaking integration
     - dependency-name: "google.golang.org/api"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.10"
@@ -88,6 +94,8 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     # Ignore Google API version, due it is breaking integration
     - dependency-name: "google.golang.org/api"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.9"


### PR DESCRIPTION
backport of https://github.com/rancher/gke-operator/pull/866