### PR TITLE
Ignore semver/v3 in dependabot due to breaking integration 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -46,6 +46,8 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     # Ignore Google API version, due it is breaking integration
     - dependency-name: "google.golang.org/api"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.9"
@@ -67,6 +69,8 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     # Ignore Google API version, due it is breaking integration
     - dependency-name: "google.golang.org/api"
+    # Ignore Google API version, due it is breaking integration
+    - dependency-name: "github.com/Masterminds/semver/v3"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.8"


### PR DESCRIPTION
backport of https://github.com/rancher/gke-operator/pull/866