### PR TITLE
[main] Add workflow to delete old images and charts for gke-operator

### DIFF
--- a/.github/workflows/delete-old-versions.yaml
+++ b/.github/workflows/delete-old-versions.yaml
@@ -1,0 +1,38 @@
+name: Delete Old Images and Charts
+on:
+  schedule:
+    - cron: '0 1 * * 1,4'  # Every Mondays and Thursdays at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  delete_old_packages:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old gke-operator images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: gke-operator
+          package-type: container
+          min-versions-to-keep: 30
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher
+
+      - name: Delete old rancher-gke-operator charts
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: rancher-gke-operator-chart/rancher-gke-operator
+          package-type: container
+          min-versions-to-keep: 7
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher
+
+      - name: Delete old rancher-gke-operator-crd charts
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: rancher-gke-operator-crd-chart/rancher-gke-operator-crd
+          package-type: container
+          min-versions-to-keep: 7
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher


### PR DESCRIPTION
Implement a scheduled workflow to automatically delete outdated images and charts for the gke-operator, retaining only the specified minimum versions.