### PR TITLE
[v2.11] Add support for auto chart bump in release GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,39 @@ jobs:
           gh release upload $TAG $f
         done
         echo "Charts successfully uploaded to GitHub release $TAG"
+    
+    - name: Add charts to branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        version=$(echo '${{ steps.goreleaser.outputs.metadata }}' | jq -r '.version')
+        branch_version=v$(echo "$version" | cut -d'.' -f1,2)
+        charts_branch=charts/$branch_version
+        if [ ! -e ~/.gitconfig ]; then
+          git config --global user.name "gke-operator-bot"
+          git config --global user.email gke-operator@suse.de
+        fi
+        echo "Publishing helm chart in the branch $charts_branch"
+        if ! git ls-remote --exit-code --heads origin "$charts_branch"; then
+          git checkout --orphan "$charts_branch"
+          git rm -rf .
+          echo "# GKE Operator Helm Charts for $branch_version versions" > README.md
+          echo "The documentation is centralized in a unique place, checkout https://github.com/rancher/gke-operator." >> README.md
+          git checkout origin/main -- License .gitignore
+          git add README.md License .gitignore
+          git commit -m "Initial commit for $charts_branch"
+        else
+          git checkout .
+          git checkout "$charts_branch"
+        fi
+        mkdir -p charts
+        for f in $(find bin/ -name '*.tgz'); do
+          tar -xf $f -C charts/
+        done
+        git add charts/**/*
+        git commit -m "Update charts to version $version"
+        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+        git push origin "$charts_branch"
   
   dispatch-dependency:
     permissions:

--- a/charts/gke-operator/Chart.yaml
+++ b/charts/gke-operator/Chart.yaml
@@ -10,11 +10,11 @@ annotations:
   catalog.cattle.io/auto-install: rancher-gke-operator-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/kube-version: ">= 1.18.0-0"
+  catalog.cattle.io/kube-version: ">= 2.11.0-0 < 2.12.0-0"
   catalog.cattle.io/namespace: cattle-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: gkeclusterconfigs.gke.cattle.io/v1
-  catalog.cattle.io/rancher-version: ">= 2.6.0-alpha"
+  catalog.cattle.io/rancher-version: ">= 1.30.0-0 < 1.33.0-0"
   catalog.cattle.io/release-name: rancher-gke-operator
   catalog.cattle.io/scope: management


### PR DESCRIPTION
### Updates
- Add support for auto chart bump in release GHA
- New charts will be pushed to the branch with the name chart/[MAJOR-VERSION].[MINOR-VERSION]
- Bump `rancher-version` and `kube-version`

### Issues:
- https://github.com/rancher/rancher/issues/49164