### PR TITLE
Add support for image pull secrets

### DIFF
--- a/charts/gke-operator/templates/_helpers.tpl
+++ b/charts/gke-operator/templates/_helpers.tpl
@@ -23,3 +23,26 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 kubernetes.io/os: linux
 {{- end -}}
 
+{{/*
+Renders imagePullSecrets, accepting either object references ({ name: <secret> })
+or plain strings, deduplicating the result.
+*/}}
+{{- define "imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+

--- a/charts/gke-operator/templates/deployment.yaml
+++ b/charts/gke-operator/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       serviceAccountName: gke-operator
+      {{- include "imagePullSecrets" . | nindent 6 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}

--- a/charts/gke-operator/values.yaml
+++ b/charts/gke-operator/values.yaml
@@ -1,6 +1,9 @@
 global:
   cattle:
     systemDefaultRegistry: ""
+    # imagePullSecrets:
+    #   - name: secret1
+    imagePullSecrets: []
 
 gkeOperator:
   image:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Adds support for image pull secrets to the chart. This allows for Rancher to automatically deploy this chart into environments which only have access to an authenticated image registry.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue # https://github.com/rancher/rancher/issues/54806

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests

I couldn't find any chart specific unit tests, but I confirmed that changes result in a valid manifest using `helm template`

<details>
<summary>
Helm Template Output 
</summary>

`helm template ./ --set 'global.cattle.imagePullSecrets[0]=regcred'`

```yaml
# Source: rancher-gke-operator/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  namespace: cattle-system
  name: gke-operator
---
# Source: rancher-gke-operator/templates/clusterrole.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: gke-operator
  namespace: cattle-system
rules:
  - apiGroups: ['']
    resources: ['secrets']
    verbs: ['get', 'list', 'create', 'watch']
  - apiGroups: ['gke.cattle.io']
    resources: ['gkeclusterconfigs']
    verbs: ['get', 'list', 'update', 'watch']
  - apiGroups: ['gke.cattle.io']
    resources: ['gkeclusterconfigs/status']
    verbs: ['update']
---
# Source: rancher-gke-operator/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name:  gke-operator
  namespace: cattle-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: gke-operator
subjects:
- kind: ServiceAccount
  name: gke-operator
  namespace: cattle-system
---
# Source: rancher-gke-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gke-config-operator
  namespace: cattle-system
spec:
  replicas: 1
  selector:
    matchLabels:
      ke.cattle.io/operator: gke
  template:
    metadata:
      labels:
        ke.cattle.io/operator: gke
    spec:
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - key: "cattle.io/os"
          value: "linux"
          effect: "NoSchedule"
          operator: "Equal"
      serviceAccountName: gke-operator
      imagePullSecrets:
        - name: regcred
      securityContext:
        fsGroup: 1007
        runAsUser: 1007
      containers:
      - name: rancher-gke-operator
        image: 'rancher/gke-operator:v0.0.0'
        imagePullPolicy: IfNotPresent
        args: ["-debug=false"]
        env:
        - name: HTTP_PROXY
          value:
        - name: HTTPS_PROXY
          value:
        - name: NO_PROXY
          value:
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
          privileged: false
          capabilities:
            drop:
            - ALL
```
</details>


- [ ] adds or updates e2e tests
- [ ] backport needed 
