### PR TITLE
Default GKE cluster creation to 'No channel' release channel

### DIFF
--- a/charts/gke-operator-crd/templates/crds.yaml
+++ b/charts/gke-operator-crd/templates/crds.yaml
@@ -249,6 +249,9 @@ spec:
               region:
                 nullable: true
                 type: string
+              releaseChannel:
+                nullable: true
+                type: string
               subnetwork:
                 nullable: true
                 type: string

--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -588,6 +588,12 @@ func (h *Handler) buildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKE
 		}
 	}
 
+	releaseChannel := gke.ReleaseChannelUnspecified
+	if cluster.ReleaseChannel != nil && cluster.ReleaseChannel.Channel != "" {
+		releaseChannel = cluster.ReleaseChannel.Channel
+	}
+	newSpec.ReleaseChannel = &releaseChannel
+
 	// build node groups
 	newSpec.NodePools = make([]gkev1.GKENodePoolConfig, 0, len(cluster.NodePools))
 

--- a/controller/gke-cluster-config-handler_test.go
+++ b/controller/gke-cluster-config-handler_test.go
@@ -223,6 +223,25 @@ var _ = Describe("buildUpstreamClusterState", func() {
 		Expect(upstreamSpec.NodePools[0].Management.AutoRepair).To(Equal(clusterState.NodePools[0].Management.AutoRepair))
 		Expect(upstreamSpec.NodePools[0].Management.AutoUpgrade).To(Equal(clusterState.NodePools[0].Management.AutoUpgrade))
 	})
+
+	It("should build upstream cluster state with no release channel", func() {
+		upstreamSpec, err := handler.buildUpstreamClusterState(clusterState)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upstreamSpec).ToNot(BeNil())
+		Expect(upstreamSpec.ReleaseChannel).ToNot(BeNil())
+		Expect(*upstreamSpec.ReleaseChannel).To(Equal(gke.ReleaseChannelUnspecified))
+	})
+
+	It("should build upstream cluster state with the upstream release channel", func() {
+		clusterState.ReleaseChannel = &gkeapi.ReleaseChannel{
+			Channel: "REGULAR",
+		}
+		upstreamSpec, err := handler.buildUpstreamClusterState(clusterState)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upstreamSpec).ToNot(BeNil())
+		Expect(upstreamSpec.ReleaseChannel).ToNot(BeNil())
+		Expect(*upstreamSpec.ReleaseChannel).To(Equal("REGULAR"))
+	})
 })
 
 const authTestJson = `

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -105,4 +105,5 @@ spec:
   - us-west1-b
   - us-west1-c
   maintenanceWindow: "00:00"
+  releaseChannel: "UNSPECIFIED"
   googleCredentialSecret: "cattle-global-data:cc-abcde"

--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -144,6 +144,15 @@ type GKEClusterConfigSpec struct {
 	// to each node in the node pool.
 	// +optional
 	CustomerManagedEncryptionKey *CMEKConfig `json:"customerManagedEncryptionKey,omitempty"`
+
+	// ReleaseChannel is the GKE release channel the cluster is enrolled in.
+	// Accepted values are UNSPECIFIED (also known as "No channel"), RAPID,
+	// REGULAR, STABLE and EXTENDED. When it is not set, standard clusters are
+	// created without a release channel (UNSPECIFIED) and autopilot clusters
+	// are enrolled in the channel selected by GKE, since they cannot opt out
+	// of release channels.
+	// +optional
+	ReleaseChannel *string `json:"releaseChannel,omitempty" norman:"pointer"`
 }
 
 type GKEIPAllocationPolicy struct {

--- a/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
@@ -247,6 +247,11 @@ func (in *GKEClusterConfigSpec) DeepCopyInto(out *GKEClusterConfigSpec) {
 		*out = new(CMEKConfig)
 		**out = **in
 	}
+	if in.ReleaseChannel != nil {
+		in, out := &in.ReleaseChannel, &out.ReleaseChannel
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gke/consts.go
+++ b/pkg/gke/consts.go
@@ -18,3 +18,10 @@ const (
 	errNotFound = "notFound"
 	errWait     = "Please wait and try again once it is done"
 )
+
+// Release channels
+const (
+	// ReleaseChannelUnspecified is the release channel used by clusters that are
+	// not enrolled in any GKE release channel, displayed as "No channel" in GCP.
+	ReleaseChannelUnspecified = "UNSPECIFIED"
+)

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -154,7 +154,32 @@ func NewClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClust
 		}
 	}
 
+	request.Cluster.ReleaseChannel = newClusterReleaseChannel(config)
+
 	return request
+}
+
+// newClusterReleaseChannel returns the release channel to set on a cluster create
+// request. GKE rejects create requests that do not explicitly select a release
+// channel, so clusters that do not configure one are created with the
+// UNSPECIFIED channel ("No channel") to preserve the previous behavior.
+// Autopilot clusters cannot opt out of release channels, so no channel is sent
+// for them unless one is configured and GKE selects the default channel.
+func newClusterReleaseChannel(config *gkev1.GKEClusterConfig) *gkeapi.ReleaseChannel {
+	channel := strings.ToUpper(strings.TrimSpace(utils.StringValue(config.Spec.ReleaseChannel)))
+	if channel == "NONE" {
+		channel = ReleaseChannelUnspecified
+	}
+	if channel == "" {
+		if config.Spec.AutopilotConfig != nil && config.Spec.AutopilotConfig.Enabled {
+			return nil
+		}
+		channel = ReleaseChannelUnspecified
+	}
+
+	return &gkeapi.ReleaseChannel{
+		Channel: channel,
+	}
 }
 
 // validateCreateRequest checks a config for the ability to generate a create request

--- a/pkg/gke/create_test.go
+++ b/pkg/gke/create_test.go
@@ -383,3 +383,99 @@ var _ = Describe("CreateNodePool", func() {
 		Expect(status).To(Equal(NotChanged))
 	})
 })
+
+var _ = Describe("NewClusterCreateRequest release channel", func() {
+	var (
+		k8sVersion      = "1.25.12-gke.200"
+		clusterIpv4Cidr = "10.42.0.0/16"
+		networkName     = "test-network"
+		subnetworkName  = "test-subnetwork"
+		emptyString     = ""
+		boolTrue        = true
+		config          *gkev1.GKEClusterConfig
+	)
+
+	BeforeEach(func() {
+		config = &gkev1.GKEClusterConfig{
+			Spec: gkev1.GKEClusterConfigSpec{
+				Region:                "test-region",
+				ProjectID:             "test-project",
+				ClusterName:           "test-cluster",
+				Locations:             []string{""},
+				Labels:                map[string]string{"test": "test"},
+				ClusterIpv4CidrBlock:  &clusterIpv4Cidr,
+				KubernetesVersion:     &k8sVersion,
+				LoggingService:        &emptyString,
+				MonitoringService:     &emptyString,
+				EnableKubernetesAlpha: &boolTrue,
+				Network:               &networkName,
+				Subnetwork:            &subnetworkName,
+				NetworkPolicyEnabled:  &boolTrue,
+				MaintenanceWindow:     &emptyString,
+				IPAllocationPolicy: &gkev1.GKEIPAllocationPolicy{
+					UseIPAliases: true,
+				},
+				ClusterAddons: &gkev1.GKEClusterAddons{
+					HTTPLoadBalancing:        true,
+					NetworkPolicyConfig:      false,
+					HorizontalPodAutoscaling: true,
+				},
+				PrivateClusterConfig: &gkev1.GKEPrivateClusterConfig{
+					EnablePrivateEndpoint: false,
+					EnablePrivateNodes:    false,
+				},
+				MasterAuthorizedNetworksConfig: &gkev1.GKEMasterAuthorizedNetworksConfig{
+					Enabled: false,
+				},
+			},
+		}
+	})
+
+	It("should default to no release channel when none is configured", func() {
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal(ReleaseChannelUnspecified))
+	})
+
+	It("should default to no release channel when an empty channel is configured", func() {
+		config.Spec.ReleaseChannel = &emptyString
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal(ReleaseChannelUnspecified))
+	})
+
+	It("should use the configured release channel", func() {
+		channel := "regular"
+		config.Spec.ReleaseChannel = &channel
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal("REGULAR"))
+	})
+
+	It("should translate a none release channel to unspecified", func() {
+		channel := "None"
+		config.Spec.ReleaseChannel = &channel
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal(ReleaseChannelUnspecified))
+	})
+
+	It("should not set a release channel for autopilot clusters when none is configured", func() {
+		config.Spec.AutopilotConfig = &gkev1.GKEAutopilotConfig{
+			Enabled: true,
+		}
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).To(BeNil())
+	})
+
+	It("should use the configured release channel for autopilot clusters", func() {
+		channel := "STABLE"
+		config.Spec.AutopilotConfig = &gkev1.GKEAutopilotConfig{
+			Enabled: true,
+		}
+		config.Spec.ReleaseChannel = &channel
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal("STABLE"))
+	})
+})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
