### PR TITLE
release-2.14 : support release channel for cluster provisioning

### DIFF
--- a/controller/gke-cluster-config-handler_test.go
+++ b/controller/gke-cluster-config-handler_test.go
@@ -426,11 +426,13 @@ var _ = Describe("createCluster", func() {
 		caSecret         *corev1.Secret
 		testNamespace    *corev1.Namespace
 		clusterState     *gkeapi.Cluster
+		serverConfig     *gkeapi.ServerConfig
 	)
 
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		gkeServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		serverConfig = &gkeapi.ServerConfig{}
 
 		clusterState = &gkeapi.Cluster{
 			Name:                 "test-cluster",
@@ -606,6 +608,19 @@ var _ = Describe("createCluster", func() {
 			gkeClient:    gkeServiceMock,
 			gkeClientCtx: context.Background(),
 		}
+
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+		gkeServiceMock.EXPECT().
+			ServerConfigGet(
+				context.Background(),
+				gke.LocationRRN(gkeConfig.Spec.ProjectID, gke.Location(gkeConfig.Spec.Region, gkeConfig.Spec.Zone))).
+			Return(serverConfig, nil).
+			AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -17,6 +17,11 @@ import (
 const (
 	cannotBeNilError            = "field [%s] cannot be nil for non-import cluster [%s (id: %s)]"
 	cannotBeNilForNodePoolError = "field [%s] cannot be nil for nodepool [%s] in non-nil cluster [%s (id: %s)]"
+	resolveReleaseChannelError  = "cannot resolve releaseChannel for kubernetesVersion [%s] for cluster [%s (id: %s)]"
+	gkeReleaseChannelRapid      = "RAPID"
+	gkeReleaseChannelRegular    = "REGULAR"
+	gkeReleaseChannelStable     = "STABLE"
+	gkeReleaseChannelExtended   = "EXTENDED"
 )
 
 // Create creates an upstream GKE cluster.
@@ -26,7 +31,21 @@ func Create(ctx context.Context, gkeClient services.GKEClusterService, config *g
 		return err
 	}
 
-	createClusterRequest := NewClusterCreateRequest(config)
+	releaseChannel := gkeReleaseChannelStable
+	if config.Spec.KubernetesVersion != nil {
+		releaseChannel, err = resolveReleaseChannelFromVersion(
+			ctx,
+			gkeClient,
+			config.Spec.ProjectID,
+			Location(config.Spec.Region, config.Spec.Zone),
+			*config.Spec.KubernetesVersion,
+		)
+		if err != nil {
+			return fmt.Errorf(resolveReleaseChannelError+": %w", *config.Spec.KubernetesVersion, config.Spec.ClusterName, config.Name, err)
+		}
+	}
+
+	createClusterRequest := newClusterCreateRequest(config, releaseChannel)
 
 	_, err = gkeClient.ClusterCreate(ctx,
 		LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
@@ -65,6 +84,10 @@ func CreateNodePool(ctx context.Context, gkeClient services.GKEClusterService, c
 
 // NewClusterCreateRequest creates a CreateClusterRequest that can be submitted to GKE
 func NewClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClusterRequest {
+	return newClusterCreateRequest(config, gkeReleaseChannelRegular)
+}
+
+func newClusterCreateRequest(config *gkev1.GKEClusterConfig, releaseChannel string) *gkeapi.CreateClusterRequest {
 	enableKubernetesAlpha := config.Spec.EnableKubernetesAlpha != nil && *config.Spec.EnableKubernetesAlpha
 	request := &gkeapi.CreateClusterRequest{
 		Cluster: &gkeapi.Cluster{
@@ -90,6 +113,9 @@ func NewClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClust
 			NodePools:         []*gkeapi.NodePool{},
 			Locations:         config.Spec.Locations,
 			MaintenancePolicy: &gkeapi.MaintenancePolicy{},
+			ReleaseChannel: &gkeapi.ReleaseChannel{
+				Channel: releaseChannel,
+			},
 		},
 	}
 
@@ -273,6 +299,49 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 	}
 
 	return nil
+}
+
+func resolveReleaseChannelFromVersion(ctx context.Context, gkeClient services.GKEClusterService, projectID, location, kubernetesVersion string) (string, error) {
+	serverConfig, err := gkeClient.ServerConfigGet(ctx, LocationRRN(projectID, location))
+	if err != nil {
+		return "", err
+	}
+	if serverConfig == nil {
+		return "", fmt.Errorf("GKE server config is nil")
+	}
+
+	priorityOrder := []string{
+		gkeReleaseChannelStable,
+		gkeReleaseChannelExtended,
+		gkeReleaseChannelRegular,
+		gkeReleaseChannelRapid,
+	}
+
+	for _, channel := range priorityOrder {
+		if supportsVersionInChannel(serverConfig.Channels, channel, kubernetesVersion) {
+			return channel, nil
+		}
+	}
+
+	return "", fmt.Errorf("kubernetes version not found in any release channel")
+}
+
+func supportsVersionInChannel(channels []*gkeapi.ReleaseChannelConfig, gkeChannel, kubernetesVersion string) bool {
+	for _, channelConfig := range channels {
+		if channelConfig == nil {
+			continue
+		}
+		if !strings.EqualFold(channelConfig.Channel, gkeChannel) {
+			continue
+		}
+		for _, validVersion := range channelConfig.ValidVersions {
+			if validVersion == kubernetesVersion {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func validateNodePoolCreateRequest(np *gkev1.GKENodePoolConfig, config *gkev1.GKEClusterConfig) error {

--- a/pkg/gke/create_test.go
+++ b/pkg/gke/create_test.go
@@ -1,6 +1,8 @@
 package gke
 
 import (
+	"errors"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,6 +22,7 @@ var _ = Describe("CreateCluster", func() {
 		subnetworkName     = "test-subnetwork"
 		emptyString        = ""
 		boolTrue           = true
+		serverConfig       = &gkeapi.ServerConfig{}
 		nodePoolName       = "test-node-pool"
 		initialNodeCount   = int64(3)
 		maxPodsConstraint  = int64(110)
@@ -58,9 +61,23 @@ var _ = Describe("CreateCluster", func() {
 		}
 	)
 
+	expectServerConfigGet := func(resp *gkeapi.ServerConfig, err error) {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(resp, err)
+	}
+
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -68,6 +85,7 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create cluster", func() {
+		expectServerConfigGet(serverConfig, nil)
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -101,6 +119,7 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create cluster with customer managment encryption key", func() {
+		expectServerConfigGet(serverConfig, nil)
 		config.Spec.CustomerManagedEncryptionKey = &gkev1.CMEKConfig{
 			KeyName:  "test-key",
 			RingName: "test-keyring",
@@ -156,6 +175,7 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create autopilot cluster", func() {
+		expectServerConfigGet(serverConfig, nil)
 		config.Spec.ClusterName = "test-autopilot-cluster"
 		config.Spec.AutopilotConfig = &gkev1.GKEAutopilotConfig{
 			Enabled: true,
@@ -268,6 +288,277 @@ var _ = Describe("CreateCluster", func() {
 		err := Create(ctx, clusterServiceMock, config)
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("should default release channel to REGULAR when omitted", func() {
+		request := NewClusterCreateRequest(config)
+		Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal("REGULAR"))
+	})
+
+	It("should resolve release channel from version during create", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		createClusterRequest := newClusterCreateRequest(config, "REGULAR")
+
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should derive release channel from version using priority order", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "RAPID",
+				ValidVersions: []string{k8sVersion},
+			},
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+			{
+				Channel:       "STABLE",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+
+		createClusterRequest := newClusterCreateRequest(config, "STABLE")
+
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail when version is not found in any release channel", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "STABLE",
+				ValidVersions: []string{"1.99.99-gke.999"},
+			},
+		}
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot resolve releaseChannel for kubernetesVersion"))
+	})
+
+	It("should resolve to RAPID when only rapid supports version", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{{
+			Channel:       "RAPID",
+			ValidVersions: []string{k8sVersion},
+		}}
+
+		createClusterRequest := newClusterCreateRequest(config, "RAPID")
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should resolve to REGULAR when regular and rapid support version", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
+			{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
+		}
+
+		createClusterRequest := newClusterCreateRequest(config, "REGULAR")
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should resolve to EXTENDED when only extended supports version", func() {
+		expectServerConfigGet(serverConfig, nil)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{{
+			Channel:       "EXTENDED",
+			ValidVersions: []string{k8sVersion},
+		}}
+
+		createClusterRequest := newClusterCreateRequest(config, "EXTENDED")
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should include upstream error when ServerConfigGet fails", func() {
+		upstreamErr := errors.New("permission denied")
+		expectServerConfigGet(nil, upstreamErr)
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot resolve releaseChannel for kubernetesVersion"))
+		Expect(err.Error()).To(ContainSubstring("permission denied"))
+	})
+})
+
+var _ = Describe("resolveReleaseChannelFromVersion", func() {
+	var (
+		mockController     *gomock.Controller
+		clusterServiceMock *mock_services.MockGKEClusterService
+		projectID          = "test-project"
+		location           = "test-location"
+		k8sVersion         = "1.25.12-gke.200"
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should prefer STABLE over REGULAR, RAPID, and EXTENDED", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(ctx, LocationRRN(projectID, location)).
+			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
+				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
+				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
+				{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
+				{Channel: "STABLE", ValidVersions: []string{k8sVersion}},
+			}}, nil)
+
+		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(channel).To(Equal("STABLE"))
+	})
+
+	It("should prefer EXTENDED over REGULAR and RAPID when STABLE is unavailable", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(ctx, LocationRRN(projectID, location)).
+			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
+				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
+				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
+				{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
+			}}, nil)
+
+		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(channel).To(Equal("EXTENDED"))
+	})
+
+	It("should prefer EXTENDED over RAPID when STABLE and REGULAR are unavailable", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(ctx, LocationRRN(projectID, location)).
+			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
+				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
+				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
+			}}, nil)
+
+		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(channel).To(Equal("EXTENDED"))
+	})
+
+	It("should resolve to EXTENDED when it is the only matching channel", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(ctx, LocationRRN(projectID, location)).
+			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
+				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
+			}}, nil)
+
+		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(channel).To(Equal("EXTENDED"))
+	})
 })
 
 var _ = Describe("CreateNodePool", func() {
@@ -280,6 +571,7 @@ var _ = Describe("CreateNodePool", func() {
 		subnetworkName     = "test-subnetwork"
 		emptyString        = ""
 		boolTrue           = true
+		serverConfig       = &gkeapi.ServerConfig{}
 
 		nodePoolName      = "test-node-pool"
 		initialNodeCount  = int64(3)
@@ -339,6 +631,12 @@ var _ = Describe("CreateNodePool", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -346,6 +644,11 @@ var _ = Describe("CreateNodePool", func() {
 	})
 
 	It("should successfully create cluster and node pool", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(serverConfig, nil)
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(

--- a/pkg/gke/delete_test.go
+++ b/pkg/gke/delete_test.go
@@ -65,6 +65,19 @@ var _ = Describe("RemoveCluster", func() {
 	})
 
 	It("should successfully remove cluster", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ServerConfig{
+				Channels: []*gkeapi.ReleaseChannelConfig{
+					{
+						Channel:       "REGULAR",
+						ValidVersions: []string{k8sVersion},
+					},
+				},
+			}, nil)
+
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -85,7 +98,9 @@ var _ = Describe("RemoveCluster", func() {
 		clusterServiceMock.EXPECT().
 			ClusterGet(
 				ctx,
-				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone),
+				ClusterRRN(
+					config.Spec.ProjectID,
+					Location(config.Spec.Region, config.Spec.Zone),
 					config.Spec.ClusterName)).
 			Return(
 				&gkeapi.Cluster{
@@ -99,7 +114,10 @@ var _ = Describe("RemoveCluster", func() {
 		clusterServiceMock.EXPECT().
 			ClusterDelete(
 				ctx,
-				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName)).
+				ClusterRRN(
+					config.Spec.ProjectID,
+					Location(config.Spec.Region, config.Spec.Zone),
+					config.Spec.ClusterName)).
 			Return(&gkeapi.Operation{}, nil)
 
 		err = RemoveCluster(ctx, clusterServiceMock, config)
@@ -183,6 +201,19 @@ var _ = Describe("RemoveNodePool", func() {
 	})
 
 	It("should successfully remove node pool", func() {
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ServerConfig{
+				Channels: []*gkeapi.ReleaseChannelConfig{
+					{
+						Channel:       "REGULAR",
+						ValidVersions: []string{k8sVersion},
+					},
+				},
+			}, nil)
+
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -205,7 +236,10 @@ var _ = Describe("RemoveNodePool", func() {
 		clusterServiceMock.EXPECT().
 			NodePoolCreate(
 				ctx,
-				ClusterRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName),
+				ClusterRRN(
+					config.Spec.ProjectID,
+					Location(config.Spec.Region, config.Spec.Zone),
+					config.Spec.ClusterName),
 				createNodePoolRequest).
 			Return(&gkeapi.Operation{}, nil)
 
@@ -216,7 +250,11 @@ var _ = Describe("RemoveNodePool", func() {
 		clusterServiceMock.EXPECT().
 			NodePoolDelete(
 				ctx,
-				NodePoolRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone), config.Spec.ClusterName, nodePoolName)).
+				NodePoolRRN(
+					config.Spec.ProjectID,
+					Location(config.Spec.Region, config.Spec.Zone),
+					config.Spec.ClusterName,
+					nodePoolName)).
 			Return(&gkeapi.Operation{}, nil)
 
 		status, err = RemoveNodePool(ctx, clusterServiceMock, config, nodePoolName)

--- a/pkg/gke/services/gke.go
+++ b/pkg/gke/services/gke.go
@@ -11,6 +11,7 @@ import (
 type GKEClusterService interface {
 	ClusterCreate(ctx context.Context, parent string, createclusterrequest *gkeapi.CreateClusterRequest) (*gkeapi.Operation, error)
 	ClusterList(ctx context.Context, parent string) (*gkeapi.ListClustersResponse, error)
+	ServerConfigGet(ctx context.Context, name string) (*gkeapi.ServerConfig, error)
 	ClusterGet(ctx context.Context, name string) (*gkeapi.Cluster, error)
 	ClusterUpdate(ctx context.Context, name string, updateclusterrequest *gkeapi.UpdateClusterRequest) (*gkeapi.Operation, error)
 	ClusterDelete(ctx context.Context, name string) (*gkeapi.Operation, error)
@@ -47,6 +48,10 @@ func (g *gkeClusterService) ClusterCreate(ctx context.Context, parent string, cr
 
 func (g *gkeClusterService) ClusterList(ctx context.Context, parent string) (*gkeapi.ListClustersResponse, error) {
 	return g.svc.Projects.Locations.Clusters.List(parent).Context(ctx).Do()
+}
+
+func (g *gkeClusterService) ServerConfigGet(ctx context.Context, name string) (*gkeapi.ServerConfig, error) {
+	return g.svc.Projects.Locations.GetServerConfig(name).Context(ctx).Do()
 }
 
 func (g *gkeClusterService) ClusterGet(ctx context.Context, name string) (*gkeapi.Cluster, error) {

--- a/pkg/gke/services/mock_services/gke_mock.go
+++ b/pkg/gke/services/mock_services/gke_mock.go
@@ -185,6 +185,21 @@ func (mr *MockGKEClusterServiceMockRecorder) NodePoolUpdate(ctx, name, updatenod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodePoolUpdate", reflect.TypeOf((*MockGKEClusterService)(nil).NodePoolUpdate), ctx, name, updatenodepoolrequest)
 }
 
+// ServerConfigGet mocks base method.
+func (m *MockGKEClusterService) ServerConfigGet(ctx context.Context, name string) (*container.ServerConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServerConfigGet", ctx, name)
+	ret0, _ := ret[0].(*container.ServerConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServerConfigGet indicates an expected call of ServerConfigGet.
+func (mr *MockGKEClusterServiceMockRecorder) ServerConfigGet(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerConfigGet", reflect.TypeOf((*MockGKEClusterService)(nil).ServerConfigGet), ctx, name)
+}
+
 // SetAutoscaling mocks base method.
 func (m *MockGKEClusterService) SetAutoscaling(ctx context.Context, name string, setnodepoolautoscalingrequest *container.SetNodePoolAutoscalingRequest) (*container.Operation, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Adds support for GKE release channels during cluster provisioning.

As of August 21, 2026, GKE requires newly provisioned clusters to be enrolled in a release channel. This change determines the appropriate release channel based on the selected Kubernetes version using the GKE ServerConfig API and sets it in the cluster provisioning request.

When a Kubernetes version is supported by multiple release channels, the most stable supported channel is selected. This is an interim approach until release-channel selection is exposed in the Rancher Dashboard.

**Which issue(s) this PR fixes**

Issue [#56879](https://github.com/rancher/rancher/issues/56879)

**Special notes for your reviewer**:

- Release channel is currently inferred from the selected Kubernetes version.
- The supported channels are Rapid, Regular, Stable, and Extended.
- The GKE ServerConfig API is used to determine which channels support the selected Kubernetes version.

**Checklist**:

- [X] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed