### PR TITLE
fix(gke): support release channel for cluster provisioning

### DIFF
--- a/charts/gke-operator-crd/templates/crds.yaml
+++ b/charts/gke-operator-crd/templates/crds.yaml
@@ -249,6 +249,9 @@ spec:
               region:
                 nullable: true
                 type: string
+              releaseChannel:
+                nullable: true
+                type: string
               subnetwork:
                 nullable: true
                 type: string

--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -310,6 +310,14 @@ func (h *Handler) updateUpstreamClusterState(config *gkev1.GKEClusterConfig, ups
 		return h.enqueueUpdate(config)
 	}
 
+	changed, err = gke.UpdateReleaseChannel(h.gkeClientCtx, h.gkeClient, config, upstreamSpec)
+	if err != nil {
+		return config, err
+	}
+	if changed == gke.Changed {
+		return h.enqueueUpdate(config)
+	}
+
 	changed, err = gke.UpdateClusterAddons(h.gkeClientCtx, h.gkeClient, config, upstreamSpec)
 	if err != nil {
 		return config, err

--- a/controller/gke-cluster-config-handler.go
+++ b/controller/gke-cluster-config-handler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	gkev1 "github.com/rancher/gke-operator/pkg/apis/gke.cattle.io/v1"
@@ -585,6 +586,24 @@ func (h *Handler) buildUpstreamClusterState(cluster *gkeapi.Cluster) (*gkev1.GKE
 	if cluster.Autopilot != nil && cluster.Autopilot.Enabled {
 		newSpec.AutopilotConfig = &gkev1.GKEAutopilotConfig{
 			Enabled: cluster.Autopilot.Enabled,
+		}
+	}
+
+	if cluster.ReleaseChannel != nil {
+		channel := strings.ToUpper(cluster.ReleaseChannel.Channel)
+		switch channel {
+		case "STABLE":
+			c := gkev1.GKEReleaseChannelStable
+			newSpec.ReleaseChannel = &c
+		case "REGULAR":
+			c := gkev1.GKEReleaseChannelRegular
+			newSpec.ReleaseChannel = &c
+		case "RAPID":
+			c := gkev1.GKEReleaseChannelRapid
+			newSpec.ReleaseChannel = &c
+		case "EXTENDED":
+			c := gkev1.GKEReleaseChannelExtended
+			newSpec.ReleaseChannel = &c
 		}
 	}
 

--- a/pkg/apis/gke.cattle.io/v1/types.go
+++ b/pkg/apis/gke.cattle.io/v1/types.go
@@ -36,6 +36,15 @@ type GKEClusterConfig struct {
 	Status GKEClusterConfigStatus `json:"status"`
 }
 
+type GKEReleaseChannel string
+
+const (
+	GKEReleaseChannelRapid    GKEReleaseChannel = "Rapid"
+	GKEReleaseChannelRegular  GKEReleaseChannel = "Regular"
+	GKEReleaseChannelStable   GKEReleaseChannel = "Stable"
+	GKEReleaseChannelExtended GKEReleaseChannel = "Extended"
+)
+
 // GKEClusterConfigSpec is the spec for a GKEClusterConfig resource
 type GKEClusterConfigSpec struct {
 	// Region is the GCP region where the cluster is located.
@@ -89,6 +98,12 @@ type GKEClusterConfigSpec struct {
 	// KubernetesVersion is the version of Kubernetes to use.
 	// +optional
 	KubernetesVersion *string `json:"kubernetesVersion" norman:"pointer"`
+
+	// ReleaseChannel is the release channel to enroll the cluster in.
+	// +optional
+	// +kubebuilder:default=Regular
+	// +kubebuilder:validation:Enum=Rapid;Regular;Stable;Extended
+	ReleaseChannel *GKEReleaseChannel `json:"releaseChannel,omitempty" norman:"pointer"`
 
 	// LoggingService is the logging service to use.
 	// +optional

--- a/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/gke.cattle.io/v1/zz_generated_deepcopy.go
@@ -180,6 +180,11 @@ func (in *GKEClusterConfigSpec) DeepCopyInto(out *GKEClusterConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ReleaseChannel != nil {
+		in, out := &in.ReleaseChannel, &out.ReleaseChannel
+		*out = new(GKEReleaseChannel)
+		**out = **in
+	}
 	if in.LoggingService != nil {
 		in, out := &in.LoggingService, &out.LoggingService
 		*out = new(string)

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -38,7 +38,7 @@ func Create(ctx context.Context, gkeClient services.GKEClusterService, config *g
 		return err
 	}
 
-	createClusterRequest := newClusterCreateRequest(config, "")
+	createClusterRequest := newClusterCreateRequest(config)
 
 	_, err = gkeClient.ClusterCreate(ctx,
 		LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
@@ -77,14 +77,12 @@ func CreateNodePool(ctx context.Context, gkeClient services.GKEClusterService, c
 
 // NewClusterCreateRequest creates a CreateClusterRequest that can be submitted to GKE
 func NewClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClusterRequest {
-	return newClusterCreateRequest(config, "")
+	return newClusterCreateRequest(config)
 }
 
-func newClusterCreateRequest(config *gkev1.GKEClusterConfig, releaseChannel string) *gkeapi.CreateClusterRequest {
+func newClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClusterRequest {
 	enableKubernetesAlpha := config.Spec.EnableKubernetesAlpha != nil && *config.Spec.EnableKubernetesAlpha
-	if releaseChannel == "" {
-		releaseChannel = gkeReleaseChannel(config.Spec.ReleaseChannel)
-	}
+	releaseChannel := gkeReleaseChannel(config.Spec.ReleaseChannel)
 	request := &gkeapi.CreateClusterRequest{
 		Cluster: &gkeapi.Cluster{
 			Name:                  config.Spec.ClusterName,
@@ -348,9 +346,6 @@ func validateAndMapReleaseChannel(specChannel *gkev1.GKEReleaseChannel) (string,
 	return mappedChannel, nil
 }
 
-// validateVersionForReleaseChannel checks that kubernetesVersion is available in the explicitly
-// requested releaseChannel. Unlike resolveReleaseChannelFromVersion, it never substitutes a
-// different channel: the caller's selection is authoritative, this only confirms it's usable.
 func validateVersionForReleaseChannel(ctx context.Context, gkeClient services.GKEClusterService, projectID, location string, releaseChannel gkev1.GKEReleaseChannel, kubernetesVersion string) error {
 	gkeChannel, err := validateAndMapReleaseChannel(&releaseChannel)
 	if err != nil {

--- a/pkg/gke/create.go
+++ b/pkg/gke/create.go
@@ -17,12 +17,19 @@ import (
 const (
 	cannotBeNilError            = "field [%s] cannot be nil for non-import cluster [%s (id: %s)]"
 	cannotBeNilForNodePoolError = "field [%s] cannot be nil for nodepool [%s] in non-nil cluster [%s (id: %s)]"
-	resolveReleaseChannelError  = "cannot resolve releaseChannel for kubernetesVersion [%s] for cluster [%s (id: %s)]. Please select a version that is available in the STABLE, REGULAR, RAPID, or EXTENDED channels"
-	gkeReleaseChannelRapid      = "RAPID"
-	gkeReleaseChannelRegular    = "REGULAR"
-	gkeReleaseChannelStable     = "STABLE"
-	gkeReleaseChannelExtended   = "EXTENDED"
+	resolveReleaseChannelError  = "cannot resolve releaseChannel for kubernetesVersion [%s] for cluster [%s (id: %s)]"
 )
+
+// errInvalidReleaseChannel is returned when a releaseChannel value is set but isn't one of the
+// supported enum values.
+var errInvalidReleaseChannel = fmt.Errorf("invalid release channel")
+
+var specToGKEReleaseChannel = map[gkev1.GKEReleaseChannel]string{
+	gkev1.GKEReleaseChannelRapid:    "RAPID",
+	gkev1.GKEReleaseChannelRegular:  "REGULAR",
+	gkev1.GKEReleaseChannelStable:   "STABLE",
+	gkev1.GKEReleaseChannelExtended: "EXTENDED",
+}
 
 // Create creates an upstream GKE cluster.
 func Create(ctx context.Context, gkeClient services.GKEClusterService, config *gkev1.GKEClusterConfig) error {
@@ -31,21 +38,7 @@ func Create(ctx context.Context, gkeClient services.GKEClusterService, config *g
 		return err
 	}
 
-	releaseChannel := gkeReleaseChannelStable
-	if config.Spec.KubernetesVersion != nil {
-		releaseChannel, err = resolveReleaseChannelFromVersion(
-			ctx,
-			gkeClient,
-			config.Spec.ProjectID,
-			Location(config.Spec.Region, config.Spec.Zone),
-			*config.Spec.KubernetesVersion,
-		)
-		if err != nil {
-			return fmt.Errorf(resolveReleaseChannelError+": %w", *config.Spec.KubernetesVersion, config.Spec.ClusterName, config.Name, err)
-		}
-	}
-
-	createClusterRequest := newClusterCreateRequest(config, releaseChannel)
+	createClusterRequest := newClusterCreateRequest(config, "")
 
 	_, err = gkeClient.ClusterCreate(ctx,
 		LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
@@ -84,11 +77,14 @@ func CreateNodePool(ctx context.Context, gkeClient services.GKEClusterService, c
 
 // NewClusterCreateRequest creates a CreateClusterRequest that can be submitted to GKE
 func NewClusterCreateRequest(config *gkev1.GKEClusterConfig) *gkeapi.CreateClusterRequest {
-	return newClusterCreateRequest(config, gkeReleaseChannelRegular)
+	return newClusterCreateRequest(config, "")
 }
 
 func newClusterCreateRequest(config *gkev1.GKEClusterConfig, releaseChannel string) *gkeapi.CreateClusterRequest {
 	enableKubernetesAlpha := config.Spec.EnableKubernetesAlpha != nil && *config.Spec.EnableKubernetesAlpha
+	if releaseChannel == "" {
+		releaseChannel = gkeReleaseChannel(config.Spec.ReleaseChannel)
+	}
 	request := &gkeapi.CreateClusterRequest{
 		Cluster: &gkeapi.Cluster{
 			Name:                  config.Spec.ClusterName,
@@ -249,6 +245,36 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 	if config.Spec.KubernetesVersion == nil {
 		return fmt.Errorf(cannotBeNilError, "kubernetesVersion", config.Spec.ClusterName, config.Name)
 	}
+
+	if config.Spec.ReleaseChannel == nil || *config.Spec.ReleaseChannel == "" {
+		// No release channel was requested: derive one automatically from the
+		// kubernetesVersion, preferring the most stable channel that supports it.
+		resolvedReleaseChannel, err := resolveReleaseChannelFromVersion(
+			ctx,
+			gkeClient,
+			config.Spec.ProjectID,
+			Location(config.Spec.Region, config.Spec.Zone),
+			*config.Spec.KubernetesVersion,
+		)
+		if err != nil {
+			return fmt.Errorf(resolveReleaseChannelError, *config.Spec.KubernetesVersion, config.Spec.ClusterName, config.Name)
+		}
+		config.Spec.ReleaseChannel = &resolvedReleaseChannel
+	} else {
+		// A release channel was explicitly requested: it must be honored as-is, and the
+		// only thing left to check is that kubernetesVersion is actually available in it.
+		if err := validateVersionForReleaseChannel(
+			ctx,
+			gkeClient,
+			config.Spec.ProjectID,
+			Location(config.Spec.Region, config.Spec.Zone),
+			*config.Spec.ReleaseChannel,
+			*config.Spec.KubernetesVersion,
+		); err != nil {
+			return fmt.Errorf("%w for cluster [%s (id: %s)]", err, config.Spec.ClusterName, config.Name)
+		}
+	}
+
 	if config.Spec.ClusterIpv4CidrBlock == nil {
 		return fmt.Errorf(cannotBeNilError, "clusterIpv4CidrBlock", config.Spec.ClusterName, config.Name)
 	}
@@ -301,25 +327,67 @@ func validateCreateRequest(ctx context.Context, gkeClient services.GKEClusterSer
 	return nil
 }
 
-func resolveReleaseChannelFromVersion(ctx context.Context, gkeClient services.GKEClusterService, projectID, location, kubernetesVersion string) (string, error) {
+func gkeReleaseChannel(specChannel *gkev1.GKEReleaseChannel) string {
+	mappedChannel, err := validateAndMapReleaseChannel(specChannel)
+	if err != nil {
+		return specToGKEReleaseChannel[gkev1.GKEReleaseChannelRegular]
+	}
+	return mappedChannel
+}
+
+func validateAndMapReleaseChannel(specChannel *gkev1.GKEReleaseChannel) (string, error) {
+	if specChannel == nil || *specChannel == "" {
+		return specToGKEReleaseChannel[gkev1.GKEReleaseChannelRegular], nil
+	}
+
+	mappedChannel, ok := specToGKEReleaseChannel[*specChannel]
+	if !ok {
+		return "", fmt.Errorf("%w [%s]", errInvalidReleaseChannel, *specChannel)
+	}
+
+	return mappedChannel, nil
+}
+
+// validateVersionForReleaseChannel checks that kubernetesVersion is available in the explicitly
+// requested releaseChannel. Unlike resolveReleaseChannelFromVersion, it never substitutes a
+// different channel: the caller's selection is authoritative, this only confirms it's usable.
+func validateVersionForReleaseChannel(ctx context.Context, gkeClient services.GKEClusterService, projectID, location string, releaseChannel gkev1.GKEReleaseChannel, kubernetesVersion string) error {
+	gkeChannel, err := validateAndMapReleaseChannel(&releaseChannel)
+	if err != nil {
+		return err
+	}
+
+	serverConfig, err := gkeClient.ServerConfigGet(ctx, LocationRRN(projectID, location))
+	if err != nil {
+		return err
+	}
+
+	if !supportsVersionInChannel(serverConfig.Channels, gkeChannel, kubernetesVersion) {
+		return fmt.Errorf("kubernetesVersion [%s] is not supported by releaseChannel [%s]", kubernetesVersion, releaseChannel)
+	}
+
+	return nil
+}
+
+func resolveReleaseChannelFromVersion(ctx context.Context, gkeClient services.GKEClusterService, projectID, location, kubernetesVersion string) (gkev1.GKEReleaseChannel, error) {
 	serverConfig, err := gkeClient.ServerConfigGet(ctx, LocationRRN(projectID, location))
 	if err != nil {
 		return "", err
 	}
-	if serverConfig == nil {
-		return "", fmt.Errorf("GKE server config is nil")
-	}
 
-	priorityOrder := []string{
-		gkeReleaseChannelStable,
-		gkeReleaseChannelRegular,
-		gkeReleaseChannelRapid,
-		gkeReleaseChannelExtended,
+	priorityOrder := []struct {
+		specChannel gkev1.GKEReleaseChannel
+		gkeChannel  string
+	}{
+		{specChannel: gkev1.GKEReleaseChannelStable, gkeChannel: "STABLE"},
+		{specChannel: gkev1.GKEReleaseChannelRegular, gkeChannel: "REGULAR"},
+		{specChannel: gkev1.GKEReleaseChannelRapid, gkeChannel: "RAPID"},
+		{specChannel: gkev1.GKEReleaseChannelExtended, gkeChannel: "EXTENDED"},
 	}
 
 	for _, channel := range priorityOrder {
-		if supportsVersionInChannel(serverConfig.Channels, channel, kubernetesVersion) {
-			return channel, nil
+		if supportsVersionInChannel(serverConfig.Channels, channel.gkeChannel, kubernetesVersion) {
+			return channel.specChannel, nil
 		}
 	}
 

--- a/pkg/gke/create_test.go
+++ b/pkg/gke/create_test.go
@@ -1,8 +1,6 @@
 package gke
 
 import (
-	"errors"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,14 +59,6 @@ var _ = Describe("CreateCluster", func() {
 		}
 	)
 
-	expectServerConfigGet := func(resp *gkeapi.ServerConfig, err error) {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(resp, err)
-	}
-
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
@@ -78,6 +68,12 @@ var _ = Describe("CreateCluster", func() {
 				ValidVersions: []string{k8sVersion},
 			},
 		}
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(serverConfig, nil).
+			AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -85,7 +81,6 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create cluster", func() {
-		expectServerConfigGet(serverConfig, nil)
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -119,7 +114,6 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create cluster with customer managment encryption key", func() {
-		expectServerConfigGet(serverConfig, nil)
 		config.Spec.CustomerManagedEncryptionKey = &gkev1.CMEKConfig{
 			KeyName:  "test-key",
 			RingName: "test-keyring",
@@ -175,7 +169,6 @@ var _ = Describe("CreateCluster", func() {
 	})
 
 	It("should successfully create autopilot cluster", func() {
-		expectServerConfigGet(serverConfig, nil)
 		config.Spec.ClusterName = "test-autopilot-cluster"
 		config.Spec.AutopilotConfig = &gkev1.GKEAutopilotConfig{
 			Enabled: true,
@@ -295,13 +288,37 @@ var _ = Describe("CreateCluster", func() {
 		Expect(request.Cluster.ReleaseChannel.Channel).To(Equal("REGULAR"))
 	})
 
-	It("should resolve release channel from version during create", func() {
-		expectServerConfigGet(serverConfig, nil)
+	It("should map release channels to expected GKE values", func() {
+		tests := []struct {
+			specValue gkev1.GKEReleaseChannel
+			expected  string
+		}{
+			{specValue: gkev1.GKEReleaseChannelRapid, expected: "RAPID"},
+			{specValue: gkev1.GKEReleaseChannelRegular, expected: "REGULAR"},
+			{specValue: gkev1.GKEReleaseChannelStable, expected: "STABLE"},
+			{specValue: gkev1.GKEReleaseChannelExtended, expected: "EXTENDED"},
+		}
+
+		for _, test := range tests {
+			c := *config.DeepCopy()
+			c.Spec.ReleaseChannel = &test.specValue
+			request := NewClusterCreateRequest(&c)
+			Expect(request.Cluster.ReleaseChannel).ToNot(BeNil())
+			Expect(request.Cluster.ReleaseChannel.Channel).To(Equal(test.expected))
+		}
+	})
+
+	It("should resolve release channel from version when empty release channel is provided", func() {
 		config.Spec.AutopilotConfig = nil
 		config.Spec.NodePools = nil
 		config.Spec.CustomerManagedEncryptionKey = nil
 		config.Spec.ClusterName = "test-cluster"
-		createClusterRequest := newClusterCreateRequest(config, "REGULAR")
+		emptyChannel := gkev1.GKEReleaseChannel("")
+		config.Spec.ReleaseChannel = &emptyChannel
+		expectedConfig := config.DeepCopy()
+		regular := gkev1.GKEReleaseChannelRegular
+		expectedConfig.Spec.ReleaseChannel = &regular
+		createClusterRequest := NewClusterCreateRequest(expectedConfig)
 
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -318,17 +335,111 @@ var _ = Describe("CreateCluster", func() {
 
 		err := Create(ctx, clusterServiceMock, config)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(config.Spec.ReleaseChannel).ToNot(BeNil())
+		Expect(*config.Spec.ReleaseChannel).To(Equal(gkev1.GKEReleaseChannelRegular))
 	})
 
-	It("should derive release channel from version using priority order", func() {
-		expectServerConfigGet(serverConfig, nil)
+	It("should reject an invalid release channel instead of silently falling back to REGULAR", func() {
 		config.Spec.AutopilotConfig = nil
 		config.Spec.NodePools = nil
 		config.Spec.CustomerManagedEncryptionKey = nil
 		config.Spec.ClusterName = "test-cluster"
+		invalidChannel := gkev1.GKEReleaseChannel("foo")
+		config.Spec.ReleaseChannel = &invalidChannel
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid release channel"))
+
+		config.Spec.ReleaseChannel = nil
+	})
+
+	It("should use the explicitly selected release channel when the version is supported, even if a higher-priority channel also supports it", func() {
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		extended := gkev1.GKEReleaseChannelExtended
+		config.Spec.ReleaseChannel = &extended
+		// STABLE also supports this version, but the user explicitly asked for EXTENDED, so
+		// EXTENDED must be what's actually provisioned, not the "safer" STABLE channel.
 		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
 			{
-				Channel:       "RAPID",
+				Channel:       "STABLE",
+				ValidVersions: []string{k8sVersion},
+			},
+			{
+				Channel:       "EXTENDED",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+
+		createClusterRequest := NewClusterCreateRequest(config)
+		Expect(createClusterRequest.Cluster.ReleaseChannel.Channel).To(Equal("EXTENDED"))
+
+		clusterServiceMock.EXPECT().
+			ClusterCreate(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
+				createClusterRequest).
+			Return(&gkeapi.Operation{}, nil)
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config.Spec.ReleaseChannel).ToNot(BeNil())
+		Expect(*config.Spec.ReleaseChannel).To(Equal(gkev1.GKEReleaseChannelExtended))
+	})
+
+	It("should reject an explicitly selected release channel when the version isn't supported by it", func() {
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		extended := gkev1.GKEReleaseChannelExtended
+		config.Spec.ReleaseChannel = &extended
+		// The version is only available in STABLE, not the requested EXTENDED channel: this
+		// must be rejected rather than silently falling back to STABLE.
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "STABLE",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+
+		clusterServiceMock.EXPECT().
+			ClusterList(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(&gkeapi.ListClustersResponse{}, nil)
+
+		err := Create(ctx, clusterServiceMock, config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not supported by releaseChannel"))
+
+		config.Spec.ReleaseChannel = nil
+	})
+
+	It("should derive release channel from version using priority order", func() {
+		config.Spec.AutopilotConfig = nil
+		config.Spec.NodePools = nil
+		config.Spec.CustomerManagedEncryptionKey = nil
+		config.Spec.ClusterName = "test-cluster"
+		config.Spec.ReleaseChannel = nil
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "STABLE",
 				ValidVersions: []string{k8sVersion},
 			},
 			{
@@ -336,12 +447,15 @@ var _ = Describe("CreateCluster", func() {
 				ValidVersions: []string{k8sVersion},
 			},
 			{
-				Channel:       "STABLE",
+				Channel:       "RAPID",
 				ValidVersions: []string{k8sVersion},
 			},
 		}
 
-		createClusterRequest := newClusterCreateRequest(config, "STABLE")
+		expectedConfig := config.DeepCopy()
+		stable := gkev1.GKEReleaseChannelStable
+		expectedConfig.Spec.ReleaseChannel = &stable
+		createClusterRequest := NewClusterCreateRequest(expectedConfig)
 
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -358,14 +472,16 @@ var _ = Describe("CreateCluster", func() {
 
 		err := Create(ctx, clusterServiceMock, config)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(config.Spec.ReleaseChannel).ToNot(BeNil())
+		Expect(*config.Spec.ReleaseChannel).To(Equal(gkev1.GKEReleaseChannelStable))
 	})
 
 	It("should fail when version is not found in any release channel", func() {
-		expectServerConfigGet(serverConfig, nil)
 		config.Spec.AutopilotConfig = nil
 		config.Spec.NodePools = nil
 		config.Spec.CustomerManagedEncryptionKey = nil
 		config.Spec.ClusterName = "test-cluster"
+		config.Spec.ReleaseChannel = nil
 		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
 			{
 				Channel:       "STABLE",
@@ -382,182 +498,6 @@ var _ = Describe("CreateCluster", func() {
 		err := Create(ctx, clusterServiceMock, config)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("cannot resolve releaseChannel for kubernetesVersion"))
-	})
-
-	It("should resolve to RAPID when only rapid supports version", func() {
-		expectServerConfigGet(serverConfig, nil)
-		config.Spec.AutopilotConfig = nil
-		config.Spec.NodePools = nil
-		config.Spec.CustomerManagedEncryptionKey = nil
-		config.Spec.ClusterName = "test-cluster"
-		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{{
-			Channel:       "RAPID",
-			ValidVersions: []string{k8sVersion},
-		}}
-
-		createClusterRequest := newClusterCreateRequest(config, "RAPID")
-		clusterServiceMock.EXPECT().
-			ClusterCreate(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
-				createClusterRequest).
-			Return(&gkeapi.Operation{}, nil)
-		clusterServiceMock.EXPECT().
-			ClusterList(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ListClustersResponse{}, nil)
-
-		err := Create(ctx, clusterServiceMock, config)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should resolve to REGULAR when regular and rapid support version", func() {
-		expectServerConfigGet(serverConfig, nil)
-		config.Spec.AutopilotConfig = nil
-		config.Spec.NodePools = nil
-		config.Spec.CustomerManagedEncryptionKey = nil
-		config.Spec.ClusterName = "test-cluster"
-		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
-			{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
-			{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
-		}
-
-		createClusterRequest := newClusterCreateRequest(config, "REGULAR")
-		clusterServiceMock.EXPECT().
-			ClusterCreate(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
-				createClusterRequest).
-			Return(&gkeapi.Operation{}, nil)
-		clusterServiceMock.EXPECT().
-			ClusterList(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ListClustersResponse{}, nil)
-
-		err := Create(ctx, clusterServiceMock, config)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should resolve to EXTENDED when only extended supports version", func() {
-		expectServerConfigGet(serverConfig, nil)
-		config.Spec.AutopilotConfig = nil
-		config.Spec.NodePools = nil
-		config.Spec.CustomerManagedEncryptionKey = nil
-		config.Spec.ClusterName = "test-cluster"
-		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{{
-			Channel:       "EXTENDED",
-			ValidVersions: []string{k8sVersion},
-		}}
-
-		createClusterRequest := newClusterCreateRequest(config, "EXTENDED")
-		clusterServiceMock.EXPECT().
-			ClusterCreate(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone)),
-				createClusterRequest).
-			Return(&gkeapi.Operation{}, nil)
-		clusterServiceMock.EXPECT().
-			ClusterList(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ListClustersResponse{}, nil)
-
-		err := Create(ctx, clusterServiceMock, config)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should include upstream error when ServerConfigGet fails", func() {
-		upstreamErr := errors.New("permission denied")
-		expectServerConfigGet(nil, upstreamErr)
-		config.Spec.AutopilotConfig = nil
-		config.Spec.NodePools = nil
-		config.Spec.CustomerManagedEncryptionKey = nil
-		config.Spec.ClusterName = "test-cluster"
-		clusterServiceMock.EXPECT().
-			ClusterList(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ListClustersResponse{}, nil)
-
-		err := Create(ctx, clusterServiceMock, config)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("cannot resolve releaseChannel for kubernetesVersion"))
-		Expect(err.Error()).To(ContainSubstring("permission denied"))
-	})
-})
-
-var _ = Describe("resolveReleaseChannelFromVersion", func() {
-	var (
-		mockController     *gomock.Controller
-		clusterServiceMock *mock_services.MockGKEClusterService
-		projectID          = "test-project"
-		location           = "test-location"
-		k8sVersion         = "1.25.12-gke.200"
-	)
-
-	BeforeEach(func() {
-		mockController = gomock.NewController(GinkgoT())
-		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
-	})
-
-	AfterEach(func() {
-		mockController.Finish()
-	})
-
-	It("should prefer STABLE over REGULAR, RAPID, and EXTENDED", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(ctx, LocationRRN(projectID, location)).
-			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
-				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
-				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
-				{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
-				{Channel: "STABLE", ValidVersions: []string{k8sVersion}},
-			}}, nil)
-
-		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(channel).To(Equal("STABLE"))
-	})
-
-	It("should prefer REGULAR over RAPID and EXTENDED when STABLE is unavailable", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(ctx, LocationRRN(projectID, location)).
-			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
-				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
-				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
-				{Channel: "REGULAR", ValidVersions: []string{k8sVersion}},
-			}}, nil)
-
-		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(channel).To(Equal("REGULAR"))
-	})
-
-	It("should prefer RAPID over EXTENDED when STABLE and REGULAR are unavailable", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(ctx, LocationRRN(projectID, location)).
-			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
-				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
-				{Channel: "RAPID", ValidVersions: []string{k8sVersion}},
-			}}, nil)
-
-		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(channel).To(Equal("RAPID"))
-	})
-
-	It("should resolve to EXTENDED when it is the only matching channel", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(ctx, LocationRRN(projectID, location)).
-			Return(&gkeapi.ServerConfig{Channels: []*gkeapi.ReleaseChannelConfig{
-				{Channel: "EXTENDED", ValidVersions: []string{k8sVersion}},
-			}}, nil)
-
-		channel, err := resolveReleaseChannelFromVersion(ctx, clusterServiceMock, projectID, location, k8sVersion)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(channel).To(Equal("EXTENDED"))
 	})
 })
 
@@ -637,6 +577,12 @@ var _ = Describe("CreateNodePool", func() {
 				ValidVersions: []string{k8sVersion},
 			},
 		}
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(serverConfig, nil).
+			AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -644,11 +590,6 @@ var _ = Describe("CreateNodePool", func() {
 	})
 
 	It("should successfully create cluster and node pool", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(serverConfig, nil)
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(

--- a/pkg/gke/delete_test.go
+++ b/pkg/gke/delete_test.go
@@ -20,6 +20,7 @@ var _ = Describe("RemoveCluster", func() {
 		subnetworkName     = "test-subnetwork"
 		emptyString        = ""
 		boolTrue           = true
+		serverConfig       = &gkeapi.ServerConfig{}
 		config             = &gkev1.GKEClusterConfig{
 			Spec: gkev1.GKEClusterConfigSpec{
 				Region:                "test-region",
@@ -58,6 +59,18 @@ var _ = Describe("RemoveCluster", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(serverConfig, nil).
+			AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -65,19 +78,6 @@ var _ = Describe("RemoveCluster", func() {
 	})
 
 	It("should successfully remove cluster", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ServerConfig{
-				Channels: []*gkeapi.ReleaseChannelConfig{
-					{
-						Channel:       "REGULAR",
-						ValidVersions: []string{k8sVersion},
-					},
-				},
-			}, nil)
-
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(
@@ -135,6 +135,7 @@ var _ = Describe("RemoveNodePool", func() {
 		subnetworkName     = "test-subnetwork"
 		emptyString        = ""
 		boolTrue           = true
+		serverConfig       = &gkeapi.ServerConfig{}
 
 		nodePoolName      = "test-node-pool"
 		initialNodeCount  = int64(3)
@@ -194,6 +195,18 @@ var _ = Describe("RemoveNodePool", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		serverConfig.Channels = []*gkeapi.ReleaseChannelConfig{
+			{
+				Channel:       "REGULAR",
+				ValidVersions: []string{k8sVersion},
+			},
+		}
+		clusterServiceMock.EXPECT().
+			ServerConfigGet(
+				ctx,
+				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
+			Return(serverConfig, nil).
+			AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -201,19 +214,6 @@ var _ = Describe("RemoveNodePool", func() {
 	})
 
 	It("should successfully remove node pool", func() {
-		clusterServiceMock.EXPECT().
-			ServerConfigGet(
-				ctx,
-				LocationRRN(config.Spec.ProjectID, Location(config.Spec.Region, config.Spec.Zone))).
-			Return(&gkeapi.ServerConfig{
-				Channels: []*gkeapi.ReleaseChannelConfig{
-					{
-						Channel:       "REGULAR",
-						ValidVersions: []string{k8sVersion},
-					},
-				},
-			}, nil)
-
 		createClusterRequest := NewClusterCreateRequest(config)
 		clusterServiceMock.EXPECT().
 			ClusterCreate(

--- a/pkg/gke/update.go
+++ b/pkg/gke/update.go
@@ -78,6 +78,53 @@ func UpdateMasterKubernetesVersion(ctx context.Context, gkeClient services.GKECl
 	return Changed, nil
 }
 
+// UpdateReleaseChannel updates the GKE cluster release channel.
+func UpdateReleaseChannel(
+	ctx context.Context,
+	gkeClient services.GKEClusterService,
+	config *gkev1.GKEClusterConfig,
+	upstreamSpec *gkev1.GKEClusterConfigSpec,
+) (Status, error) {
+	if config.Spec.ReleaseChannel == nil {
+		return NotChanged, nil
+	}
+
+	desiredChannel := gkeReleaseChannel(config.Spec.ReleaseChannel)
+
+	if upstreamSpec.ReleaseChannel != nil &&
+		*upstreamSpec.ReleaseChannel == *config.Spec.ReleaseChannel {
+		return NotChanged, nil
+	}
+
+	logrus.Infof(
+		"Updating release channel to %s for cluster [%s (id: %s)]",
+		desiredChannel,
+		config.Spec.ClusterName,
+		config.Name,
+	)
+
+	_, err := gkeClient.ClusterUpdate(
+		ctx,
+		ClusterRRN(
+			config.Spec.ProjectID,
+			Location(config.Spec.Region, config.Spec.Zone),
+			config.Spec.ClusterName,
+		),
+		&gkeapi.UpdateClusterRequest{
+			Update: &gkeapi.ClusterUpdate{
+				DesiredReleaseChannel: &gkeapi.ReleaseChannel{
+					Channel: desiredChannel,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return NotChanged, err
+	}
+
+	return Changed, nil
+}
+
 // UpdateClusterAddons updates the cluster addons.
 // In the case of the NetworkPolicyConfig addon, this may need to be retried after NetworkPolicyEnabled has been updated.
 func UpdateClusterAddons(ctx context.Context, gkeClient services.GKEClusterService, config *gkev1.GKEClusterConfig, upstreamSpec *gkev1.GKEClusterConfigSpec) (Status, error) {

--- a/pkg/gke/update_test.go
+++ b/pkg/gke/update_test.go
@@ -223,6 +223,114 @@ var _ = Describe("UpdateClusterAddons", func() {
 
 })
 
+var _ = Describe("UpdateReleaseChannel", func() {
+	var (
+		mockController     *gomock.Controller
+		clusterServiceMock *mock_services.MockGKEClusterService
+		k8sVersion         = "1.26.8-gke.110"
+		clusterIpv4Cidr    = "10.42.0.0/16"
+		networkName        = "test-network"
+		subnetworkName     = "test-subnetwork"
+		emptyString        = ""
+		boolTrue           = true
+
+		releaseChannel = gkev1.GKEReleaseChannelRegular
+		upstreamChannel = gkev1.GKEReleaseChannelStable
+
+		config = &gkev1.GKEClusterConfig{
+			Spec: gkev1.GKEClusterConfigSpec{
+				Region:                "test-region",
+				ProjectID:             "test-project",
+				ClusterName:           "test-cluster",
+				Locations:             []string{""},
+				Labels:                map[string]string{"test": "test"},
+				ClusterIpv4CidrBlock:  &clusterIpv4Cidr,
+				KubernetesVersion:     &k8sVersion,
+				ReleaseChannel:        &releaseChannel,
+				LoggingService:        &emptyString,
+				MonitoringService:     &emptyString,
+				EnableKubernetesAlpha: &boolTrue,
+				Network:               &networkName,
+				Subnetwork:            &subnetworkName,
+				NetworkPolicyEnabled:  &boolTrue,
+				MaintenanceWindow:     &emptyString,
+				IPAllocationPolicy: &gkev1.GKEIPAllocationPolicy{
+					UseIPAliases: true,
+				},
+				ClusterAddons: &gkev1.GKEClusterAddons{
+					HTTPLoadBalancing:   true,
+					NetworkPolicyConfig: false,
+					HorizontalPodAutoscaling: true,
+				},
+				PrivateClusterConfig: &gkev1.GKEPrivateClusterConfig{
+					EnablePrivateEndpoint: false,
+					EnablePrivateNodes:    false,
+				},
+				MasterAuthorizedNetworksConfig: &gkev1.GKEMasterAuthorizedNetworksConfig{
+					Enabled: false,
+				},
+			},
+		}
+
+		upstreamSpec = &gkev1.GKEClusterConfigSpec{
+			ClusterName:    "test-cluster",
+			ReleaseChannel: &upstreamChannel,
+		}
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should update release channel", func() {
+		clusterServiceMock.EXPECT().
+			ClusterUpdate(
+				ctx,
+				ClusterRRN(
+					config.Spec.ProjectID,
+					Location(config.Spec.Region, config.Spec.Zone),
+					config.Spec.ClusterName,
+				),
+				&gkeapi.UpdateClusterRequest{
+					Update: &gkeapi.ClusterUpdate{
+						DesiredReleaseChannel: &gkeapi.ReleaseChannel{
+							Channel: "REGULAR",
+						},
+					},
+				}).
+			Return(&gkeapi.Operation{}, nil)
+
+		status, err := UpdateReleaseChannel(
+			ctx,
+			clusterServiceMock,
+			config,
+			upstreamSpec,
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(Changed))
+	})
+
+	It("should not update release channel when it is already the same", func() {
+		upstreamSpec.ReleaseChannel = &releaseChannel
+
+		status, err := UpdateReleaseChannel(
+			ctx,
+			clusterServiceMock,
+			config,
+			upstreamSpec,
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(NotChanged))
+	})
+})
+
 var _ = Describe("UpdateMasterAuthorizedNetworks", func() {
 	var (
 		mockController     *gomock.Controller

--- a/pkg/gke/update_test.go
+++ b/pkg/gke/update_test.go
@@ -419,6 +419,8 @@ var _ = Describe("UpdateNodePoolAutoscaling", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		clusterServiceMock = mock_services.NewMockGKEClusterService(mockController)
+		nodePool.Autoscaling = nil
+		upstreamNodePool.Autoscaling = nil
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
## What this PR does / why we need it

[#56879](https://github.com/rancher/rancher/issues/56879)

Adds support for specifying a **GKE release channel** when provisioning a GKE cluster.

GKE now requires clusters to be enrolled in a release channel for supported Kubernetes versions. This change allows users to select one of the supported release channels:

* Rapid
* Regular
* Stable
* Extended

The selected release channel is passed through the GKE cluster configuration and used during cluster provisioning.

When a release channel is explicitly specified, the operator validates that the requested Kubernetes version is available in that channel.

If no release channel is specified, the existing automatic channel resolution behavior is retained.

## Which issue(s) this PR fixes

Issue #

## Special notes for your reviewer


## Checklist

* [x] Squashed commits into logical changes
* [] Includes documentation
* [x] Adds unit tests
* [ ] Adds or updates e2e tests
* [ ] Backport needed
